### PR TITLE
Fix don't do x auto lims when zoomed in

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## Next version
 
+### Fixed
+- x auto zoom disable when zoomed in.
+
 ### Added
 - Colour override function for lookandfeel.
 

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -663,7 +663,7 @@ void Plot::updateXData(const std::vector<std::vector<float>>& x_data) {
     i++;
   }
 
-  if (m_x_autoscale) {
+  if (m_x_autoscale && !m_x_lim) {
     setAutoXScale();
   }
 


### PR DESCRIPTION
Simply fix it so that x auto lims is not enabled when zoomed in.