### PR TITLE
Refactor, phase 0 for 3D plotting

### DIFF
--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -766,13 +766,17 @@ void Plot::deselectTracePoint(const juce::MouseEvent& event) {
 void Plot::moveSelectedTracePoints(const juce::MouseEvent& event) {
   const auto mouse_pos = getMousePositionRelativeToGraphArea(event);
 
+  // The mouse positions are relative to the graph area, so the graph bounds
+  // origin must be removed before converting them to data values.
+  const auto local_graph_bounds =
+      m_graph_bounds.getValue().withZeroOrigin().toFloat();
+
   auto d_data_position =
-      getDataPointFromPixelCoordinate(
-          mouse_pos, m_graph_bounds.getValue().toFloat(), m_x_lim, m_x_scaling,
-          m_y_lim, m_y_scaling) -
-      getDataPointFromPixelCoordinate(
-          m_prev_mouse_position, m_graph_bounds.getValue().toFloat(), m_x_lim,
-          m_x_scaling, m_y_lim, m_y_scaling);
+      getDataPointFromPixelCoordinate(mouse_pos, local_graph_bounds, m_x_lim,
+                                      m_x_scaling, m_y_lim, m_y_scaling) -
+      getDataPointFromPixelCoordinate(m_prev_mouse_position, local_graph_bounds,
+                                      m_x_lim, m_x_scaling, m_y_lim,
+                                      m_y_scaling);
 
   switch (m_pixel_point_move_type) {
     case PixelPointMoveType::horizontal: {

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_pixel_points_test.cpp
+++ b/tests/unit_tests/cmp_pixel_points_test.cpp
@@ -1,0 +1,166 @@
+#include <numeric>
+#include <vector>
+
+#include "cmp_graph_line.h"
+#include "cmp_lookandfeel.h"
+#include "cmp_test_helper.hpp"
+#include "cmp_utils.h"
+
+/* Characterization tests for the pixel-point pipeline.
+ *
+ * These tests pin down the current behaviour of
+ * PlotLookAndFeel::updateXPixelPoints/updateYPixelPoints and the full
+ * data -> pixel-point pipeline in cmp::Plot/GraphLine before the pipeline is
+ * routed through a shared per-axis transform (see docs/3d-plan.md, Phase 0).
+ *
+ * Conventions pinned down here:
+ * - Pixel points are produced in graph-area-local coordinates (only the
+ *   width/height of the graph bounds are used).
+ * - updateXPixelPoints resizes the pixel-point vector;
+ *   updateYPixelPoints expects it to be sized already, so X must be
+ *   updated before Y.
+ */
+SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
+  auto expectNear = [&](const float result, const float expected) {
+    expectWithinAbsoluteError(result, expected,
+                              1e-3f * (1.0f + std::abs(expected)));
+  };
+
+  const auto graph_bounds = juce::Rectangle<int>(0, 0, 500, 400);
+
+  auto makeIotaIndices = [](const std::size_t size) {
+    std::vector<std::size_t> indices(size);
+    std::iota(indices.begin(), indices.end(), 0u);
+    return indices;
+  };
+
+  TEST("updateXPixelPoints: linear") {
+    cmp::PlotLookAndFeel lnf;
+    const std::vector<float> x_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
+    auto indices = makeIotaIndices(x_data.size());
+    cmp::PixelPoints pixel_points;
+
+    lnf.updateXPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
+                           x_data, indices, pixel_points);
+
+    const std::vector<float> expected = {0.f, 125.f, 250.f, 375.f, 500.f};
+    expectEquals(pixel_points.size(), x_data.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+      expectNear(pixel_points[i].getX(), expected[i]);
+    }
+  }
+
+  TEST("updateYPixelPoints: linear (y-axis is inverted)") {
+    cmp::PlotLookAndFeel lnf;
+    const std::vector<float> x_data = {0.f, 5.f, 10.f};
+    const std::vector<float> y_data = {0.f, 5.f, 10.f};
+    auto indices = makeIotaIndices(y_data.size());
+    cmp::PixelPoints pixel_points;
+
+    // updateXPixelPoints must run first: it sizes the pixel-point vector.
+    lnf.updateXPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
+                           x_data, indices, pixel_points);
+    lnf.updateYPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
+                           y_data, indices, pixel_points);
+
+    const std::vector<float> expected = {400.f, 200.f, 0.f};
+    expectEquals(pixel_points.size(), y_data.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+      expectNear(pixel_points[i].getY(), expected[i]);
+    }
+  }
+
+  TEST("updateX/YPixelPoints: logarithmic") {
+    cmp::PlotLookAndFeel lnf;
+    const auto log_bounds = juce::Rectangle<int>(0, 0, 300, 300);
+    const std::vector<float> data = {1.f, 10.f, 100.f, 1000.f};
+    auto indices = makeIotaIndices(data.size());
+    cmp::PixelPoints pixel_points;
+
+    lnf.updateXPixelPoints({}, cmp::Scaling::logarithmic, {1.f, 1000.f},
+                           log_bounds, data, indices, pixel_points);
+    lnf.updateYPixelPoints({}, cmp::Scaling::logarithmic, {1.f, 1000.f},
+                           log_bounds, data, indices, pixel_points);
+
+    const std::vector<float> expected_x = {0.f, 100.f, 200.f, 300.f};
+    const std::vector<float> expected_y = {300.f, 200.f, 100.f, 0.f};
+    expectEquals(pixel_points.size(), data.size());
+    for (std::size_t i = 0; i < data.size(); ++i) {
+      expectNear(pixel_points[i].getX(), expected_x[i]);
+      expectNear(pixel_points[i].getY(), expected_y[i]);
+    }
+  }
+
+  TEST("updateX/YPixelPoints: update only some indices") {
+    cmp::PlotLookAndFeel lnf;
+    std::vector<float> x_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
+    std::vector<float> y_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
+    auto indices = makeIotaIndices(x_data.size());
+    cmp::PixelPoints pixel_points;
+
+    lnf.updateXPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
+                           x_data, indices, pixel_points);
+    lnf.updateYPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
+                           y_data, indices, pixel_points);
+
+    x_data[2] = 2.5f;
+    y_data[2] = 7.5f;
+    lnf.updateXPixelPoints({2u}, cmp::Scaling::linear, {0.f, 10.f},
+                           graph_bounds, x_data, indices, pixel_points);
+    lnf.updateYPixelPoints({2u}, cmp::Scaling::linear, {0.f, 10.f},
+                           graph_bounds, y_data, indices, pixel_points);
+
+    // Index 2 is recalculated from the new data.
+    expectNear(pixel_points[2].getX(), 125.f);
+    expectNear(pixel_points[2].getY(), 100.f);
+    // The other points are untouched.
+    expectNear(pixel_points[1].getX(), 125.f);
+    expectNear(pixel_points[1].getY(), 300.f);
+    expectNear(pixel_points[3].getX(), 375.f);
+    expectNear(pixel_points[3].getY(), 100.f);
+  }
+
+  TEST("Full pipeline: pixel points map back to the plotted data") {
+    const std::vector<float> x_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
+    const std::vector<float> y_data = {0.f, 5.f, 10.f, 5.f, 0.f};
+    const auto x_lim = cmp::Lim_f(0.f, 10.f);
+    const auto y_lim = cmp::Lim_f(0.f, 10.f);
+
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({y_data}, {x_data});
+    plot.xLim(x_lim.min, x_lim.max);
+    plot.yLim(y_lim.min, y_lim.max);
+
+    const auto graph_lines = getChildComponentHelper<cmp::GraphLine>(plot);
+    expectEquals(graph_lines.size(), 1ul);
+
+    const auto& pixel_points = graph_lines[0]->getPixelPoints();
+    const auto& pixel_point_indices = graph_lines[0]->getPixelPointIndices();
+    expectEquals(pixel_points.size(), x_data.size());
+    expectEquals(pixel_point_indices.size(), pixel_points.size());
+
+    // Pixel points are local to the graph area, so the inverse conversion
+    // uses the graph line's local bounds.
+    const auto local_bounds = graph_lines[0]->getLocalBounds().toFloat();
+    expect(!local_bounds.isEmpty());
+
+    // Tolerance of one pixel expressed in data units.
+    const auto x_tolerance =
+        (x_lim.max - x_lim.min) / local_bounds.getWidth();
+    const auto y_tolerance =
+        (y_lim.max - y_lim.min) / local_bounds.getHeight();
+
+    for (std::size_t i = 0; i < pixel_points.size(); ++i) {
+      const auto data_point = cmp::getDataPointFromPixelCoordinate(
+          pixel_points[i], local_bounds, x_lim, cmp::Scaling::linear, y_lim,
+          cmp::Scaling::linear);
+
+      expectWithinAbsoluteError(data_point.getX(),
+                                x_data[pixel_point_indices[i]], x_tolerance);
+      expectWithinAbsoluteError(data_point.getY(),
+                                y_data[pixel_point_indices[i]], y_tolerance);
+    }
+  }
+}
+;

--- a/tests/unit_tests/cmp_trace_test.cpp
+++ b/tests/unit_tests/cmp_trace_test.cpp
@@ -4,8 +4,11 @@
 #include <memory>
 
 #include "cmp_datamodels.h"
+#include "cmp_graph_line.h"
+#include "cmp_lookandfeel.h"
 #include "cmp_trace.h"
 #include "cmp_test_helper.hpp"
+#include "cmp_utils.h"
 
 using namespace cmp;
 
@@ -70,5 +73,117 @@ SECTION(TraceClass, "Trace class") {
     plot.clearTracePoints();
     auto trace_points = getChildComponentHelper<TracePoint_f>(plot);
     expect(trace_points.empty());
+  }
+}
+
+/* Lookandfeel that maps dragging a tracepoint to moving the selected trace
+ * points, like the 'move_pixel_points' example does.
+ *
+ * Note: PlotLookAndFeel::getUserInputAction caches the action map in a
+ * function-local static, so the first lookandfeel that dispatches a mouse
+ * action in this test binary decides the map. This is currently the only
+ * test that dispatches mouse events. */
+class MoveTracePointsLookAndFeel : public cmp::PlotLookAndFeel {
+  std::map<cmp::UserInput, cmp::UserInputAction> overrideUserInputMapAction(
+      std::map<cmp::UserInput, cmp::UserInputAction>
+          default_user_input_map_action) const noexcept override {
+    auto new_map = default_user_input_map_action;
+
+    new_map[cmp::UserInput::left | cmp::UserInput::drag |
+            cmp::UserInput::tracepoint] =
+        cmp::UserInputAction::move_selected_trace_points;
+
+    return new_map;
+  }
+};
+
+SECTION(MoveSelectedTracePointsTest, "Move selected trace points") {
+  auto makeMouseEvent = [](juce::Component* component,
+                           const juce::Point<float> position,
+                           const bool was_dragged) {
+    return juce::MouseEvent(
+        juce::Desktop::getInstance().getMainMouseSource(), position,
+        juce::ModifierKeys::leftButtonModifier, 0.f, 0.f, 0.f, 0.f, 0.f,
+        component, component, juce::Time::getCurrentTime(), position,
+        juce::Time::getCurrentTime(), 1, was_dragged);
+  };
+
+  TEST("Drag a selected trace point: logarithmic x, linear y") {
+    const std::vector<float> x_data = {1.f, 10.f, 100.f, 1000.f};
+    const std::vector<float> y_data = {1.f, 2.f, 3.f, 4.f};
+    const auto x_lim = cmp::Lim_f(1.f, 1000.f);
+    const auto y_lim = cmp::Lim_f(0.f, 5.f);
+
+    MoveTracePointsLookAndFeel lnf;
+    cmp::Plot plot{cmp::Scaling::logarithmic, cmp::Scaling::linear};
+    plot.setLookAndFeel(&lnf);
+    plot.setBounds(0, 0, 500, 400);
+    plot.setVisible(true);
+    plot.setMovePointsType(cmp::PixelPointMoveType::horizontal_vertical);
+    plot.plot({y_data}, {x_data});
+    plot.xLim(x_lim.min, x_lim.max);
+    plot.yLim(y_lim.min, y_lim.max);
+
+    // Create a tracepoint on the data point (10, 2) (data index 1).
+    plot.setTracePoint({10.f, 2.f});
+    const auto trace_points = getChildComponentHelper<TracePoint_f>(plot);
+    expectEquals(trace_points.size(), 1ul);
+    auto* trace_point = trace_points[0];
+
+    const auto graph_lines = getChildComponentHelper<cmp::GraphLine>(plot);
+    expectEquals(graph_lines.size(), 1ul);
+
+    // The graph line component covers the graph area.
+    const auto graph_bounds = graph_lines[0]->getBounds();
+    expect(!graph_bounds.isEmpty());
+    // The bug only shows when the graph area does not start at the origin.
+    expect(graph_bounds.getPosition() != juce::Point<int>(0, 0));
+
+    // Mouse positions are relative to the tracepoint component.
+    const auto mouse_down_pos = juce::Point<float>(3.f, 3.f);
+    const auto mouse_drag_pos = mouse_down_pos + juce::Point<float>(50.f, 20.f);
+
+    // Graph-area-local positions as Plot::getMousePositionRelativeToGraphArea
+    // computes them (positions are rounded to int pixels).
+    const auto trace_point_pos = trace_point->getBounds().getPosition();
+    const auto prev_pos_local =
+        (mouse_down_pos.toInt() + trace_point_pos - graph_bounds.getPosition())
+            .toFloat();
+    const auto new_pos_local =
+        (mouse_drag_pos.toInt() + trace_point_pos - graph_bounds.getPosition())
+            .toFloat();
+
+    // The expected data movement converts the graph-area-local pixel
+    // positions with graph-area-local (zero-origin) bounds.
+    const auto local_bounds = graph_bounds.withZeroOrigin().toFloat();
+    const auto d_x = cmp::getXDataFromXPixelCoordinate(
+                         new_pos_local.getX(), local_bounds, x_lim,
+                         cmp::Scaling::logarithmic) -
+                     cmp::getXDataFromXPixelCoordinate(
+                         prev_pos_local.getX(), local_bounds, x_lim,
+                         cmp::Scaling::logarithmic);
+    const auto d_y = cmp::getYDataFromYPixelCoordinate(
+                         new_pos_local.getY(), local_bounds, y_lim,
+                         cmp::Scaling::linear) -
+                     cmp::getYDataFromYPixelCoordinate(
+                         prev_pos_local.getY(), local_bounds, y_lim,
+                         cmp::Scaling::linear);
+    const auto expected_x = x_data[1] + d_x;
+    const auto expected_y = y_data[1] + d_y;
+
+    // Select the tracepoint and drag it.
+    plot.mouseDown(makeMouseEvent(trace_point, mouse_down_pos, false));
+    plot.mouseDrag(makeMouseEvent(trace_point, mouse_drag_pos, true));
+
+    expectWithinAbsoluteError(graph_lines[0]->getXData()[1], expected_x,
+                              1e-3f * expected_x);
+    expectWithinAbsoluteError(graph_lines[0]->getYData()[1], expected_y,
+                              1e-3f);
+
+    // The other data points are untouched.
+    expectEquals(graph_lines[0]->getXData()[0], x_data[0]);
+    expectEquals(graph_lines[0]->getYData()[2], y_data[2]);
+
+    plot.setLookAndFeel(nullptr);
   }
 }

--- a/tests/unit_tests/cmp_utils_test.cpp
+++ b/tests/unit_tests/cmp_utils_test.cpp
@@ -105,3 +105,216 @@ TEST("Float to string: 0.0") {
 }
 }
 ;
+
+/* Characterization tests for the data <-> pixel coordinate conversions.
+ *
+ * These tests pin down the current behaviour of the conversion functions in
+ * cmp_utils.h before they are refactored into a per-axis transform (see
+ * docs/3d-plan.md). Two conventions worth noting:
+ *
+ * - The forward functions (getX/YPixelValue* together with
+ *   getX/YScaleAndOffset) produce pixel values in graph-area-local
+ *   coordinates, i.e. they only use the width/height of the graph bounds.
+ * - The inverse functions (getX/YDataFromX/YPixelCoordinate) take absolute
+ *   bounds and use the bounds origin.
+ */
+SECTION(CoordinateConversionTest, "Coordinate conversions") {
+  auto expectNear = [&](const float result, const float expected) {
+    expectWithinAbsoluteError(result, expected,
+                              1e-3f * (1.0f + std::abs(expected)));
+  };
+
+  TEST("Pixel to x-data: linear") {
+    const auto bounds = juce::Rectangle<float>(0.f, 0.f, 500.f, 400.f);
+    const auto x_lim = cmp::Lim_f(0.f, 10.f);
+
+    expectNear(cmp::getXDataFromXPixelCoordinate(0.f, bounds, x_lim,
+                                                 cmp::Scaling::linear),
+               0.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(250.f, bounds, x_lim,
+                                                 cmp::Scaling::linear),
+               5.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(500.f, bounds, x_lim,
+                                                 cmp::Scaling::linear),
+               10.f);
+  }
+
+  TEST("Pixel to x-data: linear with bounds offset") {
+    const auto bounds = juce::Rectangle<float>(50.f, 30.f, 500.f, 400.f);
+    const auto x_lim = cmp::Lim_f(0.f, 10.f);
+
+    expectNear(cmp::getXDataFromXPixelCoordinate(50.f, bounds, x_lim,
+                                                 cmp::Scaling::linear),
+               0.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(300.f, bounds, x_lim,
+                                                 cmp::Scaling::linear),
+               5.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(550.f, bounds, x_lim,
+                                                 cmp::Scaling::linear),
+               10.f);
+  }
+
+  TEST("Pixel to x-data: logarithmic") {
+    const auto bounds = juce::Rectangle<float>(0.f, 0.f, 300.f, 400.f);
+    const auto x_lim = cmp::Lim_f(1.f, 1000.f);
+
+    expectNear(cmp::getXDataFromXPixelCoordinate(0.f, bounds, x_lim,
+                                                 cmp::Scaling::logarithmic),
+               1.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(100.f, bounds, x_lim,
+                                                 cmp::Scaling::logarithmic),
+               10.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(200.f, bounds, x_lim,
+                                                 cmp::Scaling::logarithmic),
+               100.f);
+    expectNear(cmp::getXDataFromXPixelCoordinate(300.f, bounds, x_lim,
+                                                 cmp::Scaling::logarithmic),
+               1000.f);
+  }
+
+  TEST("Pixel to y-data: linear (y-axis is inverted)") {
+    const auto bounds = juce::Rectangle<float>(0.f, 0.f, 500.f, 400.f);
+    const auto y_lim = cmp::Lim_f(0.f, 10.f);
+
+    expectNear(cmp::getYDataFromYPixelCoordinate(0.f, bounds, y_lim,
+                                                 cmp::Scaling::linear),
+               10.f);
+    expectNear(cmp::getYDataFromYPixelCoordinate(100.f, bounds, y_lim,
+                                                 cmp::Scaling::linear),
+               7.5f);
+    expectNear(cmp::getYDataFromYPixelCoordinate(400.f, bounds, y_lim,
+                                                 cmp::Scaling::linear),
+               0.f);
+  }
+
+  TEST("Pixel to y-data: logarithmic") {
+    const auto bounds = juce::Rectangle<float>(0.f, 0.f, 500.f, 300.f);
+    const auto y_lim = cmp::Lim_f(1.f, 1000.f);
+
+    expectNear(cmp::getYDataFromYPixelCoordinate(0.f, bounds, y_lim,
+                                                 cmp::Scaling::logarithmic),
+               1000.f);
+    expectNear(cmp::getYDataFromYPixelCoordinate(100.f, bounds, y_lim,
+                                                 cmp::Scaling::logarithmic),
+               100.f);
+    expectNear(cmp::getYDataFromYPixelCoordinate(200.f, bounds, y_lim,
+                                                 cmp::Scaling::logarithmic),
+               10.f);
+    expectNear(cmp::getYDataFromYPixelCoordinate(300.f, bounds, y_lim,
+                                                 cmp::Scaling::logarithmic),
+               1.f);
+  }
+
+  TEST("X-data to pixel: linear") {
+    const auto [x_scale, x_offset] =
+        cmp::getXScaleAndOffset(500.f, {0.f, 10.f}, cmp::Scaling::linear);
+
+    expectNear(cmp::getXPixelValueLinear(0.f, x_scale, x_offset), 0.f);
+    expectNear(cmp::getXPixelValueLinear(5.f, x_scale, x_offset), 250.f);
+    expectNear(cmp::getXPixelValueLinear(10.f, x_scale, x_offset), 500.f);
+  }
+
+  TEST("X-data to pixel: linear with negative limits") {
+    const auto [x_scale, x_offset] =
+        cmp::getXScaleAndOffset(500.f, {-5.f, 5.f}, cmp::Scaling::linear);
+
+    expectNear(cmp::getXPixelValueLinear(-5.f, x_scale, x_offset), 0.f);
+    expectNear(cmp::getXPixelValueLinear(0.f, x_scale, x_offset), 250.f);
+    expectNear(cmp::getXPixelValueLinear(5.f, x_scale, x_offset), 500.f);
+  }
+
+  TEST("X-data to pixel: logarithmic") {
+    const auto [x_scale, x_offset] =
+        cmp::getXScaleAndOffset(300.f, {1.f, 1000.f}, cmp::Scaling::logarithmic);
+
+    expectNear(cmp::getXPixelValueLogarithmic(1.f, x_scale, x_offset), 0.f);
+    expectNear(cmp::getXPixelValueLogarithmic(10.f, x_scale, x_offset), 100.f);
+    expectNear(cmp::getXPixelValueLogarithmic(1000.f, x_scale, x_offset),
+               300.f);
+  }
+
+  TEST("Y-data to pixel: linear (y-axis is inverted)") {
+    const auto [y_scale, y_offset] =
+        cmp::getYScaleAndOffset(400.f, {0.f, 10.f}, cmp::Scaling::linear);
+
+    expectNear(cmp::getYPixelValueLinear(0.f, y_scale, y_offset), 400.f);
+    expectNear(cmp::getYPixelValueLinear(2.5f, y_scale, y_offset), 300.f);
+    expectNear(cmp::getYPixelValueLinear(10.f, y_scale, y_offset), 0.f);
+  }
+
+  TEST("Y-data to pixel: logarithmic") {
+    const auto [y_scale, y_offset] =
+        cmp::getYScaleAndOffset(300.f, {1.f, 1000.f}, cmp::Scaling::logarithmic);
+
+    expectNear(cmp::getYPixelValueLogarithmic(1.f, y_scale, y_offset), 300.f);
+    expectNear(cmp::getYPixelValueLogarithmic(100.f, y_scale, y_offset), 100.f);
+    expectNear(cmp::getYPixelValueLogarithmic(1000.f, y_scale, y_offset), 0.f);
+  }
+
+  TEST("Round trip: data -> pixel -> data") {
+    const auto bounds = juce::Rectangle<float>(0.f, 0.f, 500.f, 400.f);
+    const auto test_values = std::vector<float>{1.3f, 3.7f, 8.9f, 11.2f};
+
+    const auto x_lim = cmp::Lim_f(1.f, 12.f);
+    const auto y_lim = cmp::Lim_f(1.f, 12.f);
+
+    for (const auto scaling :
+         {cmp::Scaling::linear, cmp::Scaling::logarithmic}) {
+      const auto [x_scale, x_offset] =
+          cmp::getXScaleAndOffset(bounds.getWidth(), x_lim, scaling);
+      const auto [y_scale, y_offset] =
+          cmp::getYScaleAndOffset(bounds.getHeight(), y_lim, scaling);
+
+      for (const auto value : test_values) {
+        const auto x_pixel =
+            scaling == cmp::Scaling::linear
+                ? cmp::getXPixelValueLinear(value, x_scale, x_offset)
+                : cmp::getXPixelValueLogarithmic(value, x_scale, x_offset);
+        const auto y_pixel =
+            scaling == cmp::Scaling::linear
+                ? cmp::getYPixelValueLinear(value, y_scale, y_offset)
+                : cmp::getYPixelValueLogarithmic(value, y_scale, y_offset);
+
+        expectNear(
+            cmp::getXDataFromXPixelCoordinate(x_pixel, bounds, x_lim, scaling),
+            value);
+        expectNear(
+            cmp::getYDataFromYPixelCoordinate(y_pixel, bounds, y_lim, scaling),
+            value);
+      }
+    }
+  }
+
+  TEST("Round trip: pixel -> data -> pixel") {
+    const auto bounds = juce::Rectangle<float>(0.f, 0.f, 500.f, 400.f);
+    const auto x_lim = cmp::Lim_f(0.5f, 200.f);
+    const auto y_lim = cmp::Lim_f(0.5f, 200.f);
+
+    for (const auto scaling :
+         {cmp::Scaling::linear, cmp::Scaling::logarithmic}) {
+      const auto [x_scale, x_offset] =
+          cmp::getXScaleAndOffset(bounds.getWidth(), x_lim, scaling);
+      const auto [y_scale, y_offset] =
+          cmp::getYScaleAndOffset(bounds.getHeight(), y_lim, scaling);
+
+      for (const auto pixel : {0.f, 123.f, 250.f, 399.f}) {
+        const auto x_data =
+            cmp::getXDataFromXPixelCoordinate(pixel, bounds, x_lim, scaling);
+        const auto x_pixel =
+            scaling == cmp::Scaling::linear
+                ? cmp::getXPixelValueLinear(x_data, x_scale, x_offset)
+                : cmp::getXPixelValueLogarithmic(x_data, x_scale, x_offset);
+        expectWithinAbsoluteError(x_pixel, pixel, 0.1f);
+
+        const auto y_data =
+            cmp::getYDataFromYPixelCoordinate(pixel, bounds, y_lim, scaling);
+        const auto y_pixel =
+            scaling == cmp::Scaling::linear
+                ? cmp::getYPixelValueLinear(y_data, y_scale, y_offset)
+                : cmp::getYPixelValueLogarithmic(y_data, y_scale, y_offset);
+        expectWithinAbsoluteError(y_pixel, pixel, 0.1f);
+      }
+    }
+  }
+}
+;


### PR DESCRIPTION
## Phase 0: Safety net for 3D refactoring

Adds characterization tests to pin down current behaviour of the 2D plotting pipeline before extraction and 3D extension:

- **Coordinate conversion tests**: Data ↔ pixel mappings (linear/logarithmic, round-trips, bounds handling)
- **Pixel-point pipeline tests**: GraphLine/LookAndFeel pixel point computation with known data
- **Bug fix**: Plot::moveSelectedTracePoints had a coordinate frame mismatch on log axes—now uses zero-origin graph bounds