### PR TITLE
  Phase 1: Extract dimension-agnostic plotting primitives

### DIFF
--- a/include/include/cmp_datamodels.h
+++ b/include/include/cmp_datamodels.h
@@ -61,6 +61,8 @@ struct CommonPlotParameterView;
 struct GraphLineDataView;
 template <class ValueType>
 struct Lim;
+template <class ValueType>
+struct Axis;
 
 /*============================================================================*/
 
@@ -328,6 +330,30 @@ constexpr Lim<ValueType> operator+(const Lim<ValueType>& rhs,
 
 /** @brief A struct that defines min and max using float. */
 typedef Lim<float> Lim_f;
+
+/** @brief A template struct that describes a single plot axis: its limits
+ * and scaling. */
+template <class ValueType>
+struct Axis {
+  constexpr Axis() = default;
+
+  constexpr Axis(const Lim<ValueType> new_lim, const Scaling new_scaling)
+      : lim{new_lim}, scaling{new_scaling} {}
+
+  Lim<ValueType> lim;
+  Scaling scaling{Scaling::linear};
+
+  bool operator==(const Axis<ValueType>& rhs) const noexcept {
+    return lim == rhs.lim && scaling == rhs.scaling;
+  }
+
+  bool operator!=(const Axis<ValueType>& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+};
+
+/** @brief An axis using float limits. */
+typedef Axis<float> Axis_f;
 
 /** @brief A view of some common plot parameters. */
 struct CommonPlotParameterView {

--- a/include/include/cmp_lookandfeel_base.h
+++ b/include/include/cmp_lookandfeel_base.h
@@ -1,0 +1,177 @@
+/**
+ * @file cmp_lookandfeel_base.h
+ * @brief The dimension-agnostic part of the plot LookAndFeel interface
+ * @ingroup CustomMatPlot
+ * @details This interface contains the LookAndFeel methods that do not depend
+ *          on the dimensionality of the plot: backgrounds, frame, fonts,
+ *          margins, colours, legend, labels, trace points and user input.
+ *          The 2D-specific methods live in Plot::LookAndFeelMethods.
+ * @author Frans Rosencrantz
+ * @contact Frans.Rosencrantz@gmail.com
+ */
+
+#pragma once
+
+#include "cmp_datamodels.h"
+
+namespace cmp {
+
+/**
+ *   These methods define the dimension-agnostic part of the LookAndFeel
+ *   interface used by the plot components. The 2D-specific remainder is
+ *   defined in Plot::LookAndFeelMethods. The default implementation can be
+ *   seen in \see cmp_lookandfeel.h
+ */
+class PlotLookAndFeelBase : public juce::LookAndFeel_V4 {
+public:
+  virtual ~PlotLookAndFeelBase() = default;
+
+  /** Draw background. */
+  virtual void drawBackground(juce::Graphics &g,
+                              const juce::Rectangle<int> &bound) = 0;
+
+  /** This method draws a frame around the graph area. */
+  virtual void drawFrame(juce::Graphics &g,
+                         const juce::Rectangle<int> bounds) = 0;
+
+  /** This method draws a single graph line. */
+  virtual void
+  drawGraphLine(juce::Graphics &g, const GraphLineDataView graph_line_data,
+                const juce::Rectangle<int> &graph_line_bounds) = 0;
+
+  /** This method draws the legend. */
+  virtual void drawLegend(juce::Graphics &g,
+                          std::vector<LegendLabel> legend_info,
+                          const juce::Rectangle<int> &bound) = 0;
+
+  /** This method draws the legend background. */
+  virtual void
+  drawLegendBackground(juce::Graphics &g,
+                       const juce::Rectangle<int> &legend_bound) = 0;
+
+  /** Draw a single trace point. */
+  virtual void drawTraceLabel(juce::Graphics &g, const cmp::Label &x_label,
+                              const cmp::Label &y_label,
+                              const juce::Rectangle<int> bound) = 0;
+
+  /** This method draws the trace label background. */
+  virtual void
+  drawTraceLabelBackground(juce::Graphics &g,
+                           const juce::Rectangle<int> &trace_label_bound) = 0;
+
+  /** Draw trace point. */
+  virtual void drawTracePoint(juce::Graphics &g,
+                              const juce::Rectangle<int> &bounds) = 0;
+
+  /** This method draws the selection area (e.g. zoom area). */
+  virtual void
+  drawSelectionArea(juce::Graphics &g, juce::Point<int> &start_coordinates,
+                    const juce::Point<int> &end_coordinates,
+                    const juce::Rectangle<int> &graph_bounds) noexcept = 0;
+
+  /** A method to find and get the colour from an id. */
+  virtual CONSTEXPR20 juce::Colour
+  findAndGetColourFromId(const int colour_id) const noexcept = 0;
+
+  /** Returns the Font used for the Trace and Zoom buttons. */
+  virtual CONSTEXPR20 juce::Font getButtonFont() const noexcept = 0;
+
+  /** Returns the 'ColourIdsGraph' for a given index.*/
+  virtual CONSTEXPR20 int
+  getColourFromGraphID(const std::size_t graph_index) const = 0;
+
+  /** Get the graph bounds, where the graphs and grids are to be drawn. A plot
+   * component can be given to base the graph bounds on the grid anf axis
+   * labels. */
+  virtual CONSTEXPR20 juce::Rectangle<int> getGraphBounds(
+      const juce::Rectangle<int> bounds,
+      const juce::Component *plot_comp = nullptr) const noexcept = 0;
+
+  /** Returns the Font used when drawing the grid labels. */
+  virtual CONSTEXPR20 juce::Font getGridLabelFont() const noexcept = 0;
+
+  /** Get Maximum allowed characters for grid labels. */
+  virtual CONSTEXPR20 std::size_t
+  getMaximumAllowedCharacterGridLabel() const noexcept = 0;
+
+  /** Get the legend position */
+  virtual CONSTEXPR20 juce::Point<int> getLegendPosition(
+      const juce::Rectangle<int> &graph_bounds,
+      const juce::Rectangle<int> &legend_bounds) const noexcept = 0;
+
+  /** Get the legend bounds */
+  virtual CONSTEXPR20 juce::Rectangle<int> getLegendBounds(
+      [[maybe_unused]] const juce::Rectangle<int> &bounds,
+      const std::vector<std::string> &label_texts) const noexcept = 0;
+
+  /** Returns the Font used when drawing legends. */
+  virtual juce::Font getLegendFont() const noexcept = 0;
+
+  /** Get margin used for labels and graph bounds. */
+  virtual CONSTEXPR20 std::size_t getMargin() const noexcept = 0;
+
+  /** Get a smaller margin. */
+  virtual CONSTEXPR20 std::size_t getMarginSmall() const noexcept = 0;
+
+  /** Get pixel length of marker symbol. */
+  virtual CONSTEXPR20 std::size_t getMarkerLength() const noexcept = 0;
+
+  /** Get the bounds of the componenet (Local bounds). */
+  virtual CONSTEXPR20 juce::Rectangle<int>
+  getPlotBounds(juce::Rectangle<int> bounds) const noexcept = 0;
+
+  /** Get the Font used when drawing trace labels. */
+  virtual CONSTEXPR20 juce::Font getTraceFont() const noexcept = 0;
+
+  /** Get the local bounds used when drawing the trace label (the bounds
+   * around the x & y labels).*/
+  virtual CONSTEXPR20 juce::Rectangle<int> getTraceLabelLocalBounds(
+      const juce::Rectangle<int> &x_label_bounds,
+      const juce::Rectangle<int> &y_label_bounds) const noexcept = 0;
+
+  /** Get the local bounds used when drawing the trace point.*/
+  virtual CONSTEXPR20 juce::Rectangle<int>
+  getTracePointLocalBounds() const noexcept = 0;
+
+  /** Get x and Y trace label bounds */
+  virtual std::pair<juce::Rectangle<int>, juce::Rectangle<int>>
+  getTraceXYLabelBounds(const std::string_view x_text,
+                        const std::string_view y_text) const = 0;
+
+  /** Get the bounds for the trace and zoom button. */
+  virtual CONSTEXPR20 std::pair<juce::Rectangle<int>, juce::Rectangle<int>>
+  getTraceAndZoomButtonBounds(
+      juce::Rectangle<int> graph_bounds) const noexcept = 0;
+
+  /** Returns the Font used when drawing the x-, y-axis and title labels.
+   */
+  virtual CONSTEXPR20 juce::Font getXYTitleFont() const noexcept = 0;
+
+  /** Get defualt user input map action. */
+  virtual std::map<UserInput, UserInputAction>
+  getDefaultUserInputMapAction() const noexcept = 0;
+
+  /** Override the default user input map action. */
+  virtual std::map<UserInput, UserInputAction> overrideUserInputMapAction(
+      std::map<UserInput, UserInputAction> default_user_input_map_action)
+      const noexcept = 0;
+
+  /** Get the user input action for a given user input. */
+  virtual UserInputAction
+  getUserInputAction(UserInput user_input) const noexcept = 0;
+
+  /** Defines the default colours */
+  virtual void setDefaultPlotColours() noexcept = 0;
+
+  /** Override the default colours here or use the setCoulour function on the
+   * lnf object. */
+  virtual void overridePlotColours() noexcept = 0;
+
+  /** Update the title, x and y axis labels. */
+  virtual void updateXYTitleLabels(const juce::Rectangle<int> &bounds,
+                                   const juce::Rectangle<int> &graph_bounds,
+                                   juce::Label &x_label, juce::Label &y_label,
+                                   juce::Label &title_label) = 0;
+};
+
+}  // namespace cmp

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -14,6 +14,7 @@
 #include <memory>
 
 #include "cmp_datamodels.h"
+#include "cmp_lookandfeel_base.h"
 #include "cmp_version.h"
 
 namespace cmp {
@@ -319,24 +320,13 @@ public:
   /**
    *   These methods define a interface for the LookAndFeel class of juce.
    *   The Plot class needs a LookAndFeel, that implements these methods.
+   *   The dimension-agnostic part of the interface is defined in
+   *   \see PlotLookAndFeelBase; this class adds the 2D-specific methods.
    *   The default implementation can be seen in \see cmp_lookandfeelmethods.h
    */
-  class LookAndFeelMethods : public juce::LookAndFeel_V4 {
+  class LookAndFeelMethods : public PlotLookAndFeelBase {
   public:
     virtual ~LookAndFeelMethods() = default;
-
-    /** Draw background. */
-    virtual void drawBackground(juce::Graphics &g,
-                                const juce::Rectangle<int> &bound) = 0;
-
-    /** This method draws a frame around the graph area. */
-    virtual void drawFrame(juce::Graphics &g,
-                           const juce::Rectangle<int> bounds) = 0;
-
-    /** This method draws a single graph line. */
-    virtual void
-    drawGraphLine(juce::Graphics &g, const GraphLineDataView graph_line_data,
-                  const juce::Rectangle<int> &graph_line_bounds) = 0;
 
     /** This method draws the labels on the x and y axis. */
     virtual void drawGridLabels(juce::Graphics &g,
@@ -347,94 +337,10 @@ public:
     virtual void drawGridLine(juce::Graphics &g, const GridLine &grid_line,
                               const GridType grid_type) = 0;
 
-    /** This method draws the legend. */
-    virtual void drawLegend(juce::Graphics &g,
-                            std::vector<LegendLabel> legend_info,
-                            const juce::Rectangle<int> &bound) = 0;
-
-    /** This method draws the legend background. */
-    virtual void
-    drawLegendBackground(juce::Graphics &g,
-                         const juce::Rectangle<int> &legend_bound) = 0;
-
     /** Fill area between two graph lines. */
     virtual void drawSpread(juce::Graphics &g, const GraphLine *first_graph,
                             const GraphLine *second_graph,
                             const juce::Colour &spread_colour) = 0;
-
-    /** Draw a single trace point. */
-    virtual void drawTraceLabel(juce::Graphics &g, const cmp::Label &x_label,
-                                const cmp::Label &y_label,
-                                const juce::Rectangle<int> bound) = 0;
-
-    /** This method draws the trace label background. */
-    virtual void
-    drawTraceLabelBackground(juce::Graphics &g,
-                             const juce::Rectangle<int> &trace_label_bound) = 0;
-
-    /** Draw trace point. */
-    virtual void drawTracePoint(juce::Graphics &g,
-                                const juce::Rectangle<int> &bounds) = 0;
-
-    /** This method draws the selection area (e.g. zoom area). */
-    virtual void
-    drawSelectionArea(juce::Graphics &g, juce::Point<int> &start_coordinates,
-                      const juce::Point<int> &end_coordinates,
-                      const juce::Rectangle<int> &graph_bounds) noexcept = 0;
-
-    /** A method to find and get the colour from an id. */
-    virtual CONSTEXPR20 juce::Colour
-    findAndGetColourFromId(const int colour_id) const noexcept = 0;
-
-    /** Returns the Font used for the Trace and Zoom buttons. */
-    virtual CONSTEXPR20 juce::Font getButtonFont() const noexcept = 0;
-
-    /** Returns the 'ColourIdsGraph' for a given index.*/
-    virtual CONSTEXPR20 int
-    getColourFromGraphID(const std::size_t graph_index) const = 0;
-
-    /** Get the graph bounds, where the graphs and grids are to be drawn. A plot
-     * component can be given to base the graph bounds on the grid anf axis
-     * labels. */
-    virtual CONSTEXPR20 juce::Rectangle<int> getGraphBounds(
-        const juce::Rectangle<int> bounds,
-        const juce::Component *plot_comp = nullptr) const noexcept = 0;
-
-    /** Returns the Font used when drawing the grid labels. */
-    virtual CONSTEXPR20 juce::Font getGridLabelFont() const noexcept = 0;
-
-    /** Get Maximum allowed characters for grid labels. */
-    virtual CONSTEXPR20 std::size_t
-    getMaximumAllowedCharacterGridLabel() const noexcept = 0;
-
-    /** Get the legend position */
-    virtual CONSTEXPR20 juce::Point<int> getLegendPosition(
-        const juce::Rectangle<int> &graph_bounds,
-        const juce::Rectangle<int> &legend_bounds) const noexcept = 0;
-
-    /** Get the legend bounds */
-    virtual CONSTEXPR20 juce::Rectangle<int> getLegendBounds(
-        [[maybe_unused]] const juce::Rectangle<int> &bounds,
-        const std::vector<std::string> &label_texts) const noexcept = 0;
-
-    /** Returns the Font used when drawing legends. */
-    virtual juce::Font getLegendFont() const noexcept = 0;
-
-    /** Get margin used for labels and graph bounds. */
-    virtual CONSTEXPR20 std::size_t getMargin() const noexcept = 0;
-
-    /** Get a smaller margin. */
-    virtual CONSTEXPR20 std::size_t getMarginSmall() const noexcept = 0;
-
-    /** Get pixel length of marker symbol. */
-    virtual CONSTEXPR20 std::size_t getMarkerLength() const noexcept = 0;
-
-    /** Get the bounds of the componenet (Local bounds). */
-    virtual CONSTEXPR20 juce::Rectangle<int>
-    getPlotBounds(juce::Rectangle<int> bounds) const noexcept = 0;
-
-    /** Get the Font used when drawing trace labels. */
-    virtual CONSTEXPR20 juce::Font getTraceFont() const noexcept = 0;
 
     /** Get position for a single trace point.*/
     virtual CONSTEXPR20 juce::Point<int> getTracePointPositionFrom(
@@ -443,57 +349,13 @@ public:
         const Scaling y_scaling,
         const juce::Point<float> graph_values) const noexcept = 0;
 
-    /** Get the local bounds used when drawing the trace label (the bounds
-     * around the x & y labels).*/
-    virtual CONSTEXPR20 juce::Rectangle<int> getTraceLabelLocalBounds(
-        const juce::Rectangle<int> &x_label_bounds,
-        const juce::Rectangle<int> &y_label_bounds) const noexcept = 0;
-
-    /** Get the local bounds used when drawing the trace point.*/
-    virtual CONSTEXPR20 juce::Rectangle<int>
-    getTracePointLocalBounds() const noexcept = 0;
-
-    /** Get x and Y trace label bounds */
-    virtual std::pair<juce::Rectangle<int>, juce::Rectangle<int>>
-    getTraceXYLabelBounds(const std::string_view x_text,
-                          const std::string_view y_text) const = 0;
-
-    /** Get the bounds for the trace and zoom button. */
-    virtual CONSTEXPR20 std::pair<juce::Rectangle<int>, juce::Rectangle<int>>
-    getTraceAndZoomButtonBounds(
-        juce::Rectangle<int> graph_bounds) const noexcept = 0;
-
     /** Get distance from left of grid x-labels to right side of graph bound. */
     virtual CONSTEXPR20 int
     getXGridLabelDistanceFromGraphBound() const noexcept = 0;
 
-    /** Returns the Font used when drawing the x-, y-axis and title labels.
-     */
-    virtual CONSTEXPR20 juce::Font getXYTitleFont() const noexcept = 0;
-
     /** Get distance from top of grid x-labels to bottom of graph bound. */
     virtual CONSTEXPR20 int getYGridLabelDistanceFromGraphBound(
         const int y_grid_label_width) const noexcept = 0;
-
-    /** Get defualt user input map action. */
-    virtual std::map<UserInput, UserInputAction>
-    getDefaultUserInputMapAction() const noexcept = 0;
-
-    /** Override the default user input map action. */
-    virtual std::map<UserInput, UserInputAction> overrideUserInputMapAction(
-        std::map<UserInput, UserInputAction> default_user_input_map_action)
-        const noexcept = 0;
-
-    /** Get the user input action for a given user input. */
-    virtual UserInputAction
-    getUserInputAction(UserInput user_input) const noexcept = 0;
-
-    /** Defines the default colours */
-    virtual void setDefaultPlotColours() noexcept = 0;
-
-    /** Override the default colours here or use the setCoulour function on the
-     * lnf object. */
-    virtual void overridePlotColours() noexcept = 0;
 
     /** Updates the x-ticks with auto generated ticks. */
     virtual void
@@ -537,12 +399,6 @@ public:
                                   StringVector &y_label_ticks,
                                   LabelVector &x_axis_labels,
                                   LabelVector &y_axis_labels) = 0;
-
-    /** Update the title, x and y axis labels. */
-    virtual void updateXYTitleLabels(const juce::Rectangle<int> &bounds,
-                                     const juce::Rectangle<int> &graph_bounds,
-                                     juce::Label &x_label, juce::Label &y_label,
-                                     juce::Label &title_label) = 0;
 
     /** Is x-axis labels above or below the graph area */
     virtual CONSTEXPR20 bool isXAxisLabelsBelowGraph() const noexcept = 0;

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -373,7 +373,8 @@ public:
         std::vector<float> &y_ticks) noexcept = 0;
 
     /** Updates the x-coordinates of the pixel points used when drawing a graph
-     *  line. */
+     *  line. The caller owns the sizing of 'pixel_points'; this method only
+     *  writes coordinates. */
     virtual void updateXPixelPoints(
         const std::vector<std::size_t> &update_only_these_indices,
         const Scaling x_scaling, const Lim<float> x_lim,
@@ -383,7 +384,8 @@ public:
         PixelPoints &pixel_points) noexcept = 0;
 
     /** Updates the y-coordinates of the pixel points used when drawing a graph
-     * line. */
+     * line. The caller owns the sizing of 'pixel_points'; this method only
+     * writes coordinates. */
     virtual void updateYPixelPoints(
         const std::vector<std::size_t> &update_only_these_indices,
         const Scaling y_scaling, const Lim<float> y_lim,

--- a/include/include_internal/cmp_axis_transform.h
+++ b/include/include_internal/cmp_axis_transform.h
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2022 Frans Rosencrantz
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+/**
+ * @file cmp_axis_transform.h
+ *
+ * @brief The value <-> pixel transform along a single plot axis.
+ *
+ * @ingroup CustomMatPlotInternal
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include "cmp_datamodels.h"
+
+namespace cmp {
+
+/**
+ * @brief Maps data values to pixel coordinates (and back) along one axis.
+ *
+ * The pixel range is explicit: 'pixel_min' is the pixel coordinate of
+ * 'axis.lim.min' and 'pixel_max' is the pixel coordinate of 'axis.lim.max'.
+ * This makes the coordinate frame explicit at every call site and expresses
+ * an inverted axis (like the y-axis, where the minimum value is at the
+ * bottom of the graph area) by passing 'pixel_min > pixel_max'.
+ */
+class AxisTransform {
+ public:
+  constexpr AxisTransform(const Axis_f axis, const float pixel_min,
+                          const float pixel_max) noexcept
+      : m_axis{axis},
+        m_pixel_min{pixel_min},
+        m_scale{axis.scaling == Scaling::linear
+                    ? (pixel_max - pixel_min) / (axis.lim.max - axis.lim.min)
+                    : (pixel_max - pixel_min) /
+                          std::log10(axis.lim.max / axis.lim.min)} {}
+
+  /** @brief Map a data value to its pixel coordinate. */
+  constexpr float toPixel(const float value) const noexcept {
+    switch (m_axis.scaling) {
+      case Scaling::logarithmic:
+        return m_pixel_min + std::log10(value / m_axis.lim.min) * m_scale;
+      case Scaling::linear:
+      default:
+        return m_pixel_min + (value - m_axis.lim.min) * m_scale;
+    }
+  }
+
+  /** @brief Map a pixel coordinate back to its data value. */
+  constexpr float fromPixel(const float pixel) const noexcept {
+    switch (m_axis.scaling) {
+      case Scaling::logarithmic:
+        return m_axis.lim.min *
+               std::pow(10.0f, (pixel - m_pixel_min) / m_scale);
+      case Scaling::linear:
+      default:
+        return m_axis.lim.min + (pixel - m_pixel_min) / m_scale;
+    }
+  }
+
+ private:
+  Axis_f m_axis;
+  float m_pixel_min;
+  float m_scale;
+};
+
+}  // namespace cmp

--- a/include/include_internal/cmp_utils.h
+++ b/include/include_internal/cmp_utils.h
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <vector>
 
+#include "cmp_axis_transform.h"
 #include "juce_core/system/juce_PlatformDefs.h"
 
 namespace cmp {
@@ -108,56 +109,16 @@ getRectangleMeasures(juce::Rectangle<int> grid_area) noexcept {
 constexpr float getXDataFromXPixelCoordinate(
     const float x_pos, const juce::Rectangle<float>& bounds, const Lim_f x_lim,
     const Scaling x_scaling) noexcept {
-  const auto coordinateToXLinear = [&]() {
-    const auto x_scale = bounds.getWidth() / (x_lim.max - x_lim.min);
-    return ((x_pos - bounds.getX()) / x_scale) + x_lim.min;
-  };
-
-  const auto coordinateToXLog = [&]() {
-    return std::pow(10, ((x_pos - bounds.getX()) / bounds.getWidth()) *
-                            std::log10(x_lim.max / x_lim.min)) *
-           x_lim.min;
-  };
-
-  switch (x_scaling) {
-    case Scaling::linear:
-      return coordinateToXLinear();
-      break;
-    case Scaling::logarithmic:
-      return coordinateToXLog();
-      break;
-    default:
-      return coordinateToXLinear();
-      break;
-  }
+  return AxisTransform({x_lim, x_scaling}, bounds.getX(), bounds.getRight())
+      .fromPixel(x_pos);
 }
 
 constexpr float getYDataFromYPixelCoordinate(
     const float y_pos, const juce::Rectangle<float>& bounds, const Lim_f y_lim,
     const Scaling y_scaling) noexcept {
-  const auto coordinateToYLinear = [&]() {
-    const auto y_scale = bounds.getHeight() / std::abs(y_lim.max - y_lim.min);
-
-    return y_lim.max - ((y_pos - bounds.getY()) / y_scale);
-  };
-
-  const auto coordinateToYLog = [&]() {
-    return std::pow(10, ((bounds.getHeight() - (y_pos - bounds.getY())) /
-                         bounds.getHeight()) *
-                            std::log10(y_lim.max / y_lim.min)) *
-           y_lim.min;
-  };
-  switch (y_scaling) {
-    case Scaling::linear:
-      return coordinateToYLinear();
-      break;
-    case Scaling::logarithmic:
-      return coordinateToYLog();
-      break;
-    default:
-      return coordinateToYLinear();
-      break;
-  }
+  // The y-axis is inverted: the minimum value is at the bottom of the bounds.
+  return AxisTransform({y_lim, y_scaling}, bounds.getBottom(), bounds.getY())
+      .fromPixel(y_pos);
 }
 
 static juce::Point<float> getDataPointFromPixelCoordinate(

--- a/source/cmp_graph_line.cpp
+++ b/source/cmp_graph_line.cpp
@@ -273,6 +273,7 @@ void GraphLine::updateXIndicesAndPixelPointsIntern(
   }
 
   auto lnf = static_cast<Plot::LookAndFeelMethods*>(m_lookandfeel);
+  m_pixel_points.resize(m_x_based_ds_indices.size());
   lnf->updateXPixelPoints(update_only_these_indices, m_x_scaling, m_x_lim, m_graph_bounds,
                           m_x_data, m_x_based_ds_indices, m_pixel_points);
 }
@@ -295,6 +296,7 @@ void GraphLine::updateYIndicesAndPixelPointsIntern(
       Downsampler<float>::calculateXYBasedIdxs(m_x_based_ds_indices, m_y_data,
                                                m_xy_indices);
 
+      m_pixel_points.resize(m_xy_indices.size());
       lnf->updateXPixelPoints(update_only_these_indices, m_x_scaling, m_x_lim, m_graph_bounds,
                               m_x_data, m_xy_indices, m_pixel_points);
       break;
@@ -303,6 +305,7 @@ void GraphLine::updateYIndicesAndPixelPointsIntern(
       break;
   }
 
+  m_pixel_points.resize(m_xy_indices.size());
   lnf->updateYPixelPoints(update_only_these_indices, m_y_scaling, m_y_lim, m_graph_bounds,
                           m_y_data, m_xy_indices, m_pixel_points);
 }

--- a/source/cmp_lookandfeel.cpp
+++ b/source/cmp_lookandfeel.cpp
@@ -611,11 +611,10 @@ void PlotLookAndFeel::updateXPixelPoints(
     std::vector<std::size_t>& pixel_points_indices,
     PixelPoints& pixel_points) noexcept {
   // Pixel points are graph-area-local: x_lim.min maps to pixel 0 and
-  // x_lim.max to the graph-area width.
+  // x_lim.max to the graph-area width. The caller owns the sizing of
+  // 'pixel_points'; this method only writes coordinates.
   const auto transform = AxisTransform({x_lim, x_scaling}, 0.0f,
                                        graph_bounds.toFloat().getWidth());
-
-  pixel_points.resize(pixel_points_indices.size());
 
   if (!update_only_these_indices.empty()) {
     if (pixel_points_indices.size() != x_data.size()) {
@@ -644,6 +643,8 @@ void PlotLookAndFeel::updateYPixelPoints(
     PixelPoints& pixel_points) noexcept {
   // Pixel points are graph-area-local and the y-axis is inverted: y_lim.min
   // maps to the graph-area height (bottom) and y_lim.max to pixel 0 (top).
+  // The caller owns the sizing of 'pixel_points'; this method only writes
+  // coordinates.
   const auto transform = AxisTransform(
       {y_lim, y_scaling}, graph_bounds.toFloat().getHeight(), 0.0f);
 

--- a/source/cmp_lookandfeel.cpp
+++ b/source/cmp_lookandfeel.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "cmp_axis_transform.h"
 #include "cmp_datamodels.h"
 #include "cmp_graph_line.h"
 #include "cmp_grid.h"
@@ -609,7 +610,10 @@ void PlotLookAndFeel::updateXPixelPoints(
     const std::vector<float>& x_data,
     std::vector<std::size_t>& pixel_points_indices,
     PixelPoints& pixel_points) noexcept {
-  const auto [x_scale, x_offset] = getXScaleAndOffset(graph_bounds.toFloat().getWidth(), x_lim, x_scaling);
+  // Pixel points are graph-area-local: x_lim.min maps to pixel 0 and
+  // x_lim.max to the graph-area width.
+  const auto transform = AxisTransform({x_lim, x_scaling}, 0.0f,
+                                       graph_bounds.toFloat().getWidth());
 
   pixel_points.resize(pixel_points_indices.size());
 
@@ -621,29 +625,14 @@ void PlotLookAndFeel::updateXPixelPoints(
       // no_downsampling.
     }
 
-    if (x_scaling == Scaling::linear) {
-      for (const auto i : update_only_these_indices)
-        pixel_points[i].setX(
-            getXPixelValueLinear(x_data[i], x_scale, x_offset));
-    } else if (x_scaling == Scaling::logarithmic) {
-      for (const auto i : update_only_these_indices)
-        pixel_points[i].setX(
-            getXPixelValueLogarithmic(x_data[i], x_scale, x_offset));
-    }
+    for (const auto i : update_only_these_indices)
+      pixel_points[i].setX(transform.toPixel(x_data[i]));
     return;
   }
 
   std::size_t i{0u};
-  if (x_scaling == Scaling::linear) {
-    for (const auto i_x : pixel_points_indices) {
-      pixel_points[i++].setX(
-          getXPixelValueLinear(x_data[i_x], x_scale, x_offset));
-    }
-  } else if (x_scaling == Scaling::logarithmic) {
-    for (const auto i_x : pixel_points_indices) {
-      pixel_points[i++].setX(
-          getXPixelValueLogarithmic(x_data[i_x], x_scale, x_offset));
-    }
+  for (const auto i_x : pixel_points_indices) {
+    pixel_points[i++].setX(transform.toPixel(x_data[i_x]));
   }
 }
 
@@ -653,8 +642,10 @@ void PlotLookAndFeel::updateYPixelPoints(
     const std::vector<float>& y_data,
     const std::vector<std::size_t>& pixel_points_indices,
     PixelPoints& pixel_points) noexcept {
-  const auto [y_scale, y_offset] = getYScaleAndOffset(
-      graph_bounds.toFloat().getHeight(), y_lim, y_scaling);
+  // Pixel points are graph-area-local and the y-axis is inverted: y_lim.min
+  // maps to the graph-area height (bottom) and y_lim.max to pixel 0 (top).
+  const auto transform = AxisTransform(
+      {y_lim, y_scaling}, graph_bounds.toFloat().getHeight(), 0.0f);
 
   if (!update_only_these_indices.empty()) {
     if (pixel_points_indices.size() != y_data.size()) {
@@ -664,32 +655,16 @@ void PlotLookAndFeel::updateYPixelPoints(
       // no_downsampling.
     }
 
-    if (y_scaling == Scaling::linear) {
-      for (const auto i : update_only_these_indices)
-        pixel_points[i].setY(
-            getYPixelValueLinear(y_data[i], y_scale, y_offset));
-    } else if (y_scaling == Scaling::logarithmic) {
-      for (const auto i : update_only_these_indices)
-        pixel_points[i].setY(
-            getYPixelValueLogarithmic(y_data[i], y_scale, y_offset));
-    }
+    for (const auto i : update_only_these_indices)
+      pixel_points[i].setY(transform.toPixel(y_data[i]));
     return;
   }
 
   std::size_t i = 0u;
 
-  if (y_scaling == Scaling::linear) {
-    for (const auto i_y : pixel_points_indices) {
-      pixel_points[i].setY(
-          getYPixelValueLinear(y_data[i_y], y_scale, y_offset));
-      i++;
-    }
-  } else if (y_scaling == Scaling::logarithmic) {
-    for (const auto i_y : pixel_points_indices) {
-      pixel_points[i].setY(
-          getYPixelValueLogarithmic(y_data[i_y], y_scale, y_offset));
-      i++;
-    }
+  for (const auto i_y : pixel_points_indices) {
+    pixel_points[i].setY(transform.toPixel(y_data[i_y]));
+    i++;
   }
 }
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_axis_transform_test.cpp
+++ b/tests/unit_tests/cmp_axis_transform_test.cpp
@@ -1,0 +1,109 @@
+#include "cmp_axis_transform.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for the per-axis value <-> pixel transform.
+ *
+ * AxisTransform takes an explicit pixel range: pixel_min is the pixel of
+ * axis.lim.min and pixel_max the pixel of axis.lim.max. An inverted axis
+ * (like the y-axis) is expressed by passing pixel_min > pixel_max.
+ *
+ * The expected values mirror the characterization tests for the legacy x/y
+ * conversion functions in cmp_utils_test.cpp, which are now wrappers around
+ * this transform.
+ */
+SECTION(AxisTransformTest, "Axis transform") {
+  auto expectNear = [&](const float result, const float expected) {
+    expectWithinAbsoluteError(result, expected,
+                              1e-3f * (1.0f + std::abs(expected)));
+  };
+
+  TEST("Linear: value to pixel") {
+    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear},
+                                       0.f, 500.f);
+
+    expectNear(transform.toPixel(0.f), 0.f);
+    expectNear(transform.toPixel(5.f), 250.f);
+    expectNear(transform.toPixel(10.f), 500.f);
+  }
+
+  TEST("Linear: pixel to value") {
+    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear},
+                                       0.f, 500.f);
+
+    expectNear(transform.fromPixel(0.f), 0.f);
+    expectNear(transform.fromPixel(250.f), 5.f);
+    expectNear(transform.fromPixel(500.f), 10.f);
+  }
+
+  TEST("Linear: negative limits") {
+    const cmp::AxisTransform transform({{-5.f, 5.f}, cmp::Scaling::linear},
+                                       0.f, 500.f);
+
+    expectNear(transform.toPixel(-5.f), 0.f);
+    expectNear(transform.toPixel(0.f), 250.f);
+    expectNear(transform.fromPixel(250.f), 0.f);
+    expectNear(transform.fromPixel(500.f), 5.f);
+  }
+
+  TEST("Logarithmic: value to pixel") {
+    const cmp::AxisTransform transform(
+        {{1.f, 1000.f}, cmp::Scaling::logarithmic}, 0.f, 300.f);
+
+    expectNear(transform.toPixel(1.f), 0.f);
+    expectNear(transform.toPixel(10.f), 100.f);
+    expectNear(transform.toPixel(100.f), 200.f);
+    expectNear(transform.toPixel(1000.f), 300.f);
+  }
+
+  TEST("Logarithmic: pixel to value") {
+    const cmp::AxisTransform transform(
+        {{1.f, 1000.f}, cmp::Scaling::logarithmic}, 0.f, 300.f);
+
+    expectNear(transform.fromPixel(0.f), 1.f);
+    expectNear(transform.fromPixel(100.f), 10.f);
+    expectNear(transform.fromPixel(200.f), 100.f);
+    expectNear(transform.fromPixel(300.f), 1000.f);
+  }
+
+  TEST("Inverted axis: pixel_min > pixel_max (y-axis convention)") {
+    const cmp::AxisTransform linear({{0.f, 10.f}, cmp::Scaling::linear},
+                                    400.f, 0.f);
+
+    expectNear(linear.toPixel(0.f), 400.f);
+    expectNear(linear.toPixel(2.5f), 300.f);
+    expectNear(linear.toPixel(10.f), 0.f);
+    expectNear(linear.fromPixel(0.f), 10.f);
+    expectNear(linear.fromPixel(100.f), 7.5f);
+    expectNear(linear.fromPixel(400.f), 0.f);
+
+    const cmp::AxisTransform log({{1.f, 1000.f}, cmp::Scaling::logarithmic},
+                                 300.f, 0.f);
+
+    expectNear(log.toPixel(1.f), 300.f);
+    expectNear(log.toPixel(100.f), 100.f);
+    expectNear(log.fromPixel(0.f), 1000.f);
+    expectNear(log.fromPixel(200.f), 10.f);
+  }
+
+  TEST("Pixel range with offset") {
+    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear},
+                                       50.f, 550.f);
+
+    expectNear(transform.toPixel(0.f), 50.f);
+    expectNear(transform.toPixel(5.f), 300.f);
+    expectNear(transform.fromPixel(50.f), 0.f);
+    expectNear(transform.fromPixel(550.f), 10.f);
+  }
+
+  TEST("Round trip: value -> pixel -> value") {
+    for (const auto scaling :
+         {cmp::Scaling::linear, cmp::Scaling::logarithmic}) {
+      const cmp::AxisTransform transform({{1.f, 12.f}, scaling}, 0.f, 500.f);
+
+      for (const auto value : {1.3f, 3.7f, 8.9f, 11.2f}) {
+        expectNear(transform.fromPixel(transform.toPixel(value)), value);
+      }
+    }
+  }
+}
+;

--- a/tests/unit_tests/cmp_datamodels_test.cpp
+++ b/tests/unit_tests/cmp_datamodels_test.cpp
@@ -131,3 +131,29 @@ SECTION(ObservableTest, "Observable class tests") {
     }
   }
 }
+
+SECTION(AxisTest, "Axis struct") {
+  TEST("Default construction") {
+    constexpr Axis_f axis;
+
+    expectEquals(axis.lim.min, 0.f);
+    expectEquals(axis.lim.max, 0.f);
+    expect(axis.scaling == Scaling::linear);
+  }
+
+  TEST("Construction from limits and scaling") {
+    constexpr auto axis = Axis_f({1.f, 1000.f}, Scaling::logarithmic);
+
+    expectEquals(axis.lim.min, 1.f);
+    expectEquals(axis.lim.max, 1000.f);
+    expect(axis.scaling == Scaling::logarithmic);
+  }
+
+  TEST("Equality") {
+    const auto axis = Axis_f({0.f, 10.f}, Scaling::linear);
+
+    expect(axis == Axis_f({0.f, 10.f}, Scaling::linear));
+    expect(axis != Axis_f({0.f, 10.f}, Scaling::logarithmic));
+    expect(axis != Axis_f({0.f, 20.f}, Scaling::linear));
+  }
+}

--- a/tests/unit_tests/cmp_pixel_points_test.cpp
+++ b/tests/unit_tests/cmp_pixel_points_test.cpp
@@ -16,9 +16,9 @@
  * Conventions pinned down here:
  * - Pixel points are produced in graph-area-local coordinates (only the
  *   width/height of the graph bounds are used).
- * - updateXPixelPoints resizes the pixel-point vector;
- *   updateYPixelPoints expects it to be sized already, so X must be
- *   updated before Y.
+ * - The caller owns the sizing of the pixel-point vector;
+ *   updateXPixelPoints/updateYPixelPoints only write coordinates, so they
+ *   can run in any order.
  */
 SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
   auto expectNear = [&](const float result, const float expected) {
@@ -38,7 +38,7 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
     cmp::PlotLookAndFeel lnf;
     const std::vector<float> x_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
     auto indices = makeIotaIndices(x_data.size());
-    cmp::PixelPoints pixel_points;
+    cmp::PixelPoints pixel_points(indices.size());
 
     lnf.updateXPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
                            x_data, indices, pixel_points);
@@ -55,9 +55,8 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
     const std::vector<float> x_data = {0.f, 5.f, 10.f};
     const std::vector<float> y_data = {0.f, 5.f, 10.f};
     auto indices = makeIotaIndices(y_data.size());
-    cmp::PixelPoints pixel_points;
+    cmp::PixelPoints pixel_points(indices.size());
 
-    // updateXPixelPoints must run first: it sizes the pixel-point vector.
     lnf.updateXPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
                            x_data, indices, pixel_points);
     lnf.updateYPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
@@ -75,7 +74,7 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
     const auto log_bounds = juce::Rectangle<int>(0, 0, 300, 300);
     const std::vector<float> data = {1.f, 10.f, 100.f, 1000.f};
     auto indices = makeIotaIndices(data.size());
-    cmp::PixelPoints pixel_points;
+    cmp::PixelPoints pixel_points(indices.size());
 
     lnf.updateXPixelPoints({}, cmp::Scaling::logarithmic, {1.f, 1000.f},
                            log_bounds, data, indices, pixel_points);
@@ -96,7 +95,7 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
     std::vector<float> x_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
     std::vector<float> y_data = {0.f, 2.5f, 5.f, 7.5f, 10.f};
     auto indices = makeIotaIndices(x_data.size());
-    cmp::PixelPoints pixel_points;
+    cmp::PixelPoints pixel_points(indices.size());
 
     lnf.updateXPixelPoints({}, cmp::Scaling::linear, {0.f, 10.f}, graph_bounds,
                            x_data, indices, pixel_points);


### PR DESCRIPTION
## Summary

  Refactors the 2D plotting infrastructure to extract dimension-agnostic primitives needed for 3D support. All existing 2D behavior is preserved; this is a structural reorganization to unblock Phases 2–3
  (3D math and Plot3D component).

  ### What changed

  - **Axis struct** (`cmp_datamodels.h`): bundles `Lim` + `Scaling` for a single axis
  - **AxisTransform** (`cmp_axis_transform.h`): per-axis value↔pixel conversion (linear/logarithmic, inverted axis via swapped pixel range)
  - **PlotLookAndFeelBase** (`cmp_lookandfeel_base.h`): dimension-agnostic LookAndFeel methods (background, frame, legend, trace, user input)
  - **Plot::LookAndFeelMethods**: now inherits from `PlotLookAndFeelBase`; retains only 2D-specific methods (grid, ticks, spread)
  - **GraphLine**: owns pixel-point vector sizing; `updateXPixelPoints`/`updateYPixelPoints` now only write coordinates

  ### Bug fixes

  - **Logarithmic axis point-moving**: fixed frame mismatch in `Plot::moveSelectedTracePoints` (was using absolute bounds with graph-local delta). Covered by regression test.

  ### Test coverage

  - Characterization tests for coordinate conversions (linear/log round trips, bounds offsets)
  - Characterization tests for pixel-point pipeline
  - Unit tests for `Axis` and `AxisTransform`
  - Regression test for log-axis point-moving

  All 63 tests pass.

  ### Design notes

  The explicit pixel range in `AxisTransform` (`pixel_min`, `pixel_max`) makes the coordinate frame unambiguous at every call site and expresses axis inversion naturally (y-axis: `pixel_min > pixel_max`).
  Legacy conversion functions in `cmp_utils.h` are now thin wrappers.

  Vector sizing moved into `GraphLine` removes the implicit X-before-Y ordering dependency between `updateXPixelPoints` and `updateYPixelPoints`.

  This is the foundation for Phase 2 (3D math: `Vec3`, `Camera3D`, `Projector3D`) and Phase 3 (minimal working `Plot3D`).

  You can create the PR on GitHub using this title and description, or install the GitHub CLI (gh) if you prefer command-line.