### PR TITLE
Refactor/3d phase 2

### DIFF
--- a/include/include_internal/cmp_camera3d.h
+++ b/include/include_internal/cmp_camera3d.h
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2022 Frans Rosencrantz
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+/**
+ * @file cmp_camera3d.h
+ *
+ * @brief The camera used to view 3D plot data.
+ *
+ * @ingroup CustomMatPlotInternal
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include "cmp_math3d.h"
+
+namespace cmp {
+
+/**
+ * @brief An orthographic camera defined by azimuth and elevation, following
+ * MATLAB's view(az, el) convention.
+ *
+ * The azimuth is the horizontal rotation about the z-axis in degrees,
+ * measured counter-clockwise from the negative y-axis. The elevation is the
+ * angle above the xy-plane in degrees. The default view is MATLAB's default
+ * 3D view: view(-37.5, 30).
+ *
+ * 'toViewSpace' rotates a point into view space, where x points right on the
+ * screen, y points up on the screen, and z is the depth towards the camera
+ * (a larger z is closer to the viewer).
+ */
+class Camera3D {
+ public:
+  Camera3D() noexcept { setView(-37.5f, 30.0f); }
+
+  Camera3D(const float azimuth_degrees, const float elevation_degrees) noexcept {
+    setView(azimuth_degrees, elevation_degrees);
+  }
+
+  /** @brief Set the view angles, like MATLAB's view(az, el). */
+  void setView(const float azimuth_degrees,
+               const float elevation_degrees) noexcept {
+    m_azimuth_degrees = azimuth_degrees;
+    m_elevation_degrees = elevation_degrees;
+
+    const auto cos_az = std::cos(juce::degreesToRadians(azimuth_degrees));
+    const auto sin_az = std::sin(juce::degreesToRadians(azimuth_degrees));
+    const auto cos_el = std::cos(juce::degreesToRadians(elevation_degrees));
+    const auto sin_el = std::sin(juce::degreesToRadians(elevation_degrees));
+
+    m_screen_x_dir = {cos_az, sin_az, 0.0f};
+    m_screen_y_dir = {-sin_el * sin_az, sin_el * cos_az, cos_el};
+    m_depth_dir = {cos_el * sin_az, -cos_el * cos_az, sin_el};
+  }
+
+  float getAzimuthDegrees() const noexcept { return m_azimuth_degrees; }
+
+  float getElevationDegrees() const noexcept { return m_elevation_degrees; }
+
+  /** @brief Rotate a point into view space: x = screen right, y = screen up,
+   * z = depth towards the camera. */
+  Vec3f toViewSpace(const Vec3f& point) const noexcept {
+    return {m_screen_x_dir.dot(point), m_screen_y_dir.dot(point),
+            m_depth_dir.dot(point)};
+  }
+
+ private:
+  float m_azimuth_degrees, m_elevation_degrees;
+  Vec3f m_screen_x_dir, m_screen_y_dir, m_depth_dir;
+};
+
+}  // namespace cmp

--- a/include/include_internal/cmp_math3d.h
+++ b/include/include_internal/cmp_math3d.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2022 Frans Rosencrantz
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+/**
+ * @file cmp_math3d.h
+ *
+ * @brief 3D math primitives used by the 3D plotting pipeline.
+ *
+ * @ingroup CustomMatPlotInternal
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include "cmp_datamodels.h"
+
+namespace cmp {
+
+/** @brief A template struct that defines a 3D point/vector. */
+template <class ValueType>
+struct Vec3 {
+  ValueType x{}, y{}, z{};
+
+  constexpr Vec3 operator+(const Vec3& rhs) const noexcept {
+    return {x + rhs.x, y + rhs.y, z + rhs.z};
+  }
+
+  constexpr Vec3 operator-(const Vec3& rhs) const noexcept {
+    return {x - rhs.x, y - rhs.y, z - rhs.z};
+  }
+
+  constexpr Vec3 operator*(const ValueType scalar) const noexcept {
+    return {x * scalar, y * scalar, z * scalar};
+  }
+
+  constexpr bool operator==(const Vec3& rhs) const noexcept {
+    return x == rhs.x && y == rhs.y && z == rhs.z;
+  }
+
+  constexpr bool operator!=(const Vec3& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+
+  constexpr ValueType dot(const Vec3& rhs) const noexcept {
+    return x * rhs.x + y * rhs.y + z * rhs.z;
+  }
+
+  constexpr Vec3 cross(const Vec3& rhs) const noexcept {
+    return {y * rhs.z - z * rhs.y, z * rhs.x - x * rhs.z,
+            x * rhs.y - y * rhs.x};
+  }
+
+  ValueType length() const noexcept { return std::sqrt(dot(*this)); }
+};
+
+/** @brief A 3D point/vector using float. */
+typedef Vec3<float> Vec3f;
+
+/** @brief The three axes of a 3D plot. */
+struct Axes3 {
+  Axis_f x, y, z;
+};
+
+}  // namespace cmp

--- a/include/include_internal/cmp_projector3d.h
+++ b/include/include_internal/cmp_projector3d.h
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2022 Frans Rosencrantz
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+/**
+ * @file cmp_projector3d.h
+ *
+ * @brief Projects 3D data points into 2D pixel points.
+ *
+ * @ingroup CustomMatPlotInternal
+ */
+
+#pragma once
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "cmp_axis_transform.h"
+#include "cmp_camera3d.h"
+#include "cmp_math3d.h"
+
+namespace cmp {
+
+/**
+ * @brief Projects (x, y, z) data points into graph-area-local pixel points.
+ *
+ * The data cube spanned by the three axis limits is normalized into a unit
+ * cube centered on the origin (logarithmic axes are normalized in log
+ * space), rotated into view space by the camera, and fitted into the graph
+ * bounds: the view-space bounding box of the data cube is stretched to fill
+ * the graph area, like the 2D pipeline stretches the x/y limits and like
+ * MATLAB's default 'stretch' camera mode.
+ *
+ * Pixel points are graph-area-local, matching the 2D pixel-point pipeline,
+ * so everything downstream of pixel points can be reused.
+ */
+class Projector3D {
+ public:
+  Projector3D(const Axes3& axes, const Camera3D& camera,
+              const juce::Rectangle<int>& graph_bounds) noexcept
+      : Projector3D(axes, camera, graph_bounds, viewSpaceBoundingBox(camera)) {
+  }
+
+  /** @brief Project a single data point to its graph-area-local pixel
+   * point. */
+  juce::Point<float> toPixel(const Vec3f& data_point) const noexcept {
+    const auto view_point = m_camera.toViewSpace(toCenteredUnitCube(data_point));
+
+    return {m_screen_x.toPixel(view_point.x), m_screen_y.toPixel(view_point.y)};
+  }
+
+  /** @brief Project the given data to pixel points. The pixel-point vector
+   * is resized to the data size. */
+  void updatePixelPoints(const std::vector<float>& x_data,
+                         const std::vector<float>& y_data,
+                         const std::vector<float>& z_data,
+                         PixelPoints& pixel_points) const {
+    pixel_points.resize(x_data.size());
+
+    for (std::size_t i = 0; i < x_data.size(); ++i) {
+      pixel_points[i] = toPixel({x_data[i], y_data[i], z_data[i]});
+    }
+  }
+
+ private:
+  Projector3D(const Axes3& axes, const Camera3D& camera,
+              const juce::Rectangle<int>& graph_bounds,
+              const std::pair<Lim_f, Lim_f>& view_bounding_box) noexcept
+      : m_axes{axes},
+        m_camera{camera},
+        m_screen_x{{view_bounding_box.first, Scaling::linear}, 0.0f,
+                   static_cast<float>(graph_bounds.getWidth())},
+        // The y-axis is inverted: the bottom of the view-space bounding box
+        // maps to the graph-area height.
+        m_screen_y{{view_bounding_box.second, Scaling::linear},
+                   static_cast<float>(graph_bounds.getHeight()), 0.0f} {}
+
+  /** Normalize a value into [0, 1] along one axis. */
+  static float toUnitRange(const float value, const Axis_f& axis) noexcept {
+    if (axis.scaling == Scaling::logarithmic) {
+      return std::log10(value / axis.lim.min) /
+             std::log10(axis.lim.max / axis.lim.min);
+    }
+
+    return (value - axis.lim.min) / (axis.lim.max - axis.lim.min);
+  }
+
+  /** Normalize a data point into the unit cube centered on the origin. */
+  Vec3f toCenteredUnitCube(const Vec3f& data_point) const noexcept {
+    return {toUnitRange(data_point.x, m_axes.x) - 0.5f,
+            toUnitRange(data_point.y, m_axes.y) - 0.5f,
+            toUnitRange(data_point.z, m_axes.z) - 0.5f};
+  }
+
+  /** The view-space x/y bounding box of the centered unit cube. */
+  static std::pair<Lim_f, Lim_f> viewSpaceBoundingBox(
+      const Camera3D& camera) noexcept {
+    auto x_lim = Lim_f(0.0f, 0.0f);
+    auto y_lim = Lim_f(0.0f, 0.0f);
+
+    for (const auto x : {-0.5f, 0.5f}) {
+      for (const auto y : {-0.5f, 0.5f}) {
+        for (const auto z : {-0.5f, 0.5f}) {
+          const auto corner = camera.toViewSpace({x, y, z});
+
+          x_lim.min = std::min(x_lim.min, corner.x);
+          x_lim.max = std::max(x_lim.max, corner.x);
+          y_lim.min = std::min(y_lim.min, corner.y);
+          y_lim.max = std::max(y_lim.max, corner.y);
+        }
+      }
+    }
+
+    return {x_lim, y_lim};
+  }
+
+  Axes3 m_axes;
+  Camera3D m_camera;
+  AxisTransform m_screen_x, m_screen_y;
+};
+
+}  // namespace cmp

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_camera3d_test.cpp
+++ b/tests/unit_tests/cmp_camera3d_test.cpp
@@ -1,0 +1,80 @@
+#include "cmp_camera3d.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for the 3D camera.
+ *
+ * The view convention follows MATLAB's view(az, el): azimuth rotates about
+ * the z-axis counter-clockwise from the negative y-axis, elevation is the
+ * angle above the xy-plane. View space is x = screen right, y = screen up,
+ * z = depth towards the camera.
+ */
+SECTION(Camera3DTest, "3D camera") {
+  auto expectNear = [&](const float result, const float expected) {
+    expectWithinAbsoluteError(result, expected, 1e-4f);
+  };
+
+  auto expectVecNear = [&](const cmp::Vec3f result, const cmp::Vec3f expected) {
+    expectWithinAbsoluteError(result.x, expected.x, 1e-4f);
+    expectWithinAbsoluteError(result.y, expected.y, 1e-4f);
+    expectWithinAbsoluteError(result.z, expected.z, 1e-4f);
+  };
+
+  TEST("Front view: view(0, 0) shows the xz-plane") {
+    const cmp::Camera3D camera(0.f, 0.f);
+
+    // Screen x = data x, screen y = data z, depth = -data y (the camera
+    // looks from the negative y-axis towards positive y).
+    expectVecNear(camera.toViewSpace({1.f, 2.f, 3.f}), {1.f, 3.f, -2.f});
+  }
+
+  TEST("Side view: view(90, 0) shows the yz-plane") {
+    const cmp::Camera3D camera(90.f, 0.f);
+
+    expectVecNear(camera.toViewSpace({1.f, 2.f, 3.f}), {2.f, 3.f, 1.f});
+  }
+
+  TEST("Top view: view(0, 90) shows the xy-plane") {
+    const cmp::Camera3D camera(0.f, 90.f);
+
+    expectVecNear(camera.toViewSpace({1.f, 2.f, 3.f}), {1.f, 2.f, 3.f});
+  }
+
+  TEST("Default view is MATLAB's view(-37.5, 30)") {
+    const cmp::Camera3D camera;
+
+    expectNear(camera.getAzimuthDegrees(), -37.5f);
+    expectNear(camera.getElevationDegrees(), 30.f);
+
+    // Where the unit-cube corner (1, 1, 1) lands, computed from
+    // viewmtx(-37.5, 30).
+    expectVecNear(camera.toViewSpace({1.f, 1.f, 1.f}),
+                  {0.18459f, 1.56708f, -0.71427f});
+    expectVecNear(camera.toViewSpace({0.f, 0.f, 0.f}), {0.f, 0.f, 0.f});
+  }
+
+  TEST("View transform is a rotation: lengths are preserved") {
+    for (const auto camera :
+         {cmp::Camera3D(), cmp::Camera3D(123.f, -45.f), cmp::Camera3D(0.f, 0.f)}) {
+      const auto point = cmp::Vec3f{1.f, 2.f, 3.f};
+
+      expectNear(camera.toViewSpace(point).length(), point.length());
+    }
+  }
+
+  TEST("Azimuth is periodic: view(az, el) == view(az + 360, el)") {
+    const cmp::Camera3D camera_a(-37.5f, 30.f);
+    const cmp::Camera3D camera_b(-37.5f + 360.f, 30.f);
+    const auto point = cmp::Vec3f{1.f, 2.f, 3.f};
+
+    expectVecNear(camera_a.toViewSpace(point), camera_b.toViewSpace(point));
+  }
+
+  TEST("setView updates the view") {
+    cmp::Camera3D camera(0.f, 0.f);
+    camera.setView(0.f, 90.f);
+
+    expectNear(camera.getElevationDegrees(), 90.f);
+    expectVecNear(camera.toViewSpace({1.f, 2.f, 3.f}), {1.f, 2.f, 3.f});
+  }
+}
+;

--- a/tests/unit_tests/cmp_math3d_test.cpp
+++ b/tests/unit_tests/cmp_math3d_test.cpp
@@ -1,0 +1,68 @@
+#include "cmp_math3d.h"
+#include "cmp_test_helper.hpp"
+
+SECTION(Math3DTest, "3D math primitives") {
+  auto expectNear = [&](const float result, const float expected) {
+    expectWithinAbsoluteError(result, expected,
+                              1e-5f * (1.0f + std::abs(expected)));
+  };
+
+  TEST("Vec3: default construction is zero") {
+    constexpr cmp::Vec3f v;
+
+    expectEquals(v.x, 0.f);
+    expectEquals(v.y, 0.f);
+    expectEquals(v.z, 0.f);
+  }
+
+  TEST("Vec3: addition and subtraction") {
+    constexpr auto a = cmp::Vec3f{1.f, 2.f, 3.f};
+    constexpr auto b = cmp::Vec3f{4.f, 5.f, 6.f};
+
+    expect(a + b == cmp::Vec3f{5.f, 7.f, 9.f});
+    expect(b - a == cmp::Vec3f{3.f, 3.f, 3.f});
+  }
+
+  TEST("Vec3: scalar multiplication") {
+    constexpr auto v = cmp::Vec3f{1.f, -2.f, 3.f};
+
+    expect(v * 2.f == cmp::Vec3f{2.f, -4.f, 6.f});
+    expect(v * 0.f == cmp::Vec3f{});
+  }
+
+  TEST("Vec3: dot product") {
+    constexpr auto a = cmp::Vec3f{1.f, 2.f, 3.f};
+    constexpr auto b = cmp::Vec3f{4.f, -5.f, 6.f};
+
+    expectNear(a.dot(b), 12.f);
+    expectNear(a.dot(a), 14.f);
+  }
+
+  TEST("Vec3: cross product") {
+    constexpr auto x = cmp::Vec3f{1.f, 0.f, 0.f};
+    constexpr auto y = cmp::Vec3f{0.f, 1.f, 0.f};
+    constexpr auto z = cmp::Vec3f{0.f, 0.f, 1.f};
+
+    expect(x.cross(y) == z);
+    expect(y.cross(z) == x);
+    expect(z.cross(x) == y);
+    expect(y.cross(x) == z * -1.f);
+  }
+
+  TEST("Vec3: length") {
+    expectNear(cmp::Vec3f{3.f, 4.f, 0.f}.length(), 5.f);
+    expectNear(cmp::Vec3f{1.f, 2.f, 2.f}.length(), 3.f);
+    expectNear(cmp::Vec3f{}.length(), 0.f);
+  }
+
+  TEST("Axes3: bundles three axes") {
+    const auto axes = cmp::Axes3{{{0.f, 1.f}, cmp::Scaling::linear},
+                                 {{0.f, 2.f}, cmp::Scaling::linear},
+                                 {{1.f, 1000.f}, cmp::Scaling::logarithmic}};
+
+    expect(axes.x == cmp::Axis_f({0.f, 1.f}, cmp::Scaling::linear));
+    expect(axes.y == cmp::Axis_f({0.f, 2.f}, cmp::Scaling::linear));
+    expect(axes.z == cmp::Axis_f({1.f, 1000.f}, cmp::Scaling::logarithmic));
+  }
+}
+;

--- a/tests/unit_tests/cmp_projector3d_test.cpp
+++ b/tests/unit_tests/cmp_projector3d_test.cpp
@@ -1,0 +1,106 @@
+#include <vector>
+
+#include "cmp_projector3d.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for the 3D -> 2D projector.
+ *
+ * Pixel points are graph-area-local, like the 2D pixel-point pipeline: the
+ * view-space bounding box of the data cube is stretched to fill the graph
+ * bounds, with the pixel y-axis pointing down.
+ */
+SECTION(Projector3DTest, "3D projector") {
+  auto expectPointNear = [&](const juce::Point<float> result,
+                             const juce::Point<float> expected) {
+    expectWithinAbsoluteError(result.getX(), expected.getX(), 1e-2f);
+    expectWithinAbsoluteError(result.getY(), expected.getY(), 1e-2f);
+  };
+
+  const auto graph_bounds = juce::Rectangle<int>(0, 0, 500, 400);
+
+  const auto linear_axes =
+      cmp::Axes3{{{0.f, 10.f}, cmp::Scaling::linear},
+                 {{0.f, 10.f}, cmp::Scaling::linear},
+                 {{0.f, 10.f}, cmp::Scaling::linear}};
+
+  TEST("Top view: x maps across the width, y up the height") {
+    const cmp::Camera3D top_view(0.f, 90.f);
+    const cmp::Projector3D projector(linear_axes, top_view, graph_bounds);
+
+    // (x_min, y_min) is the bottom-left corner of the graph area.
+    expectPointNear(projector.toPixel({0.f, 0.f, 5.f}), {0.f, 400.f});
+    expectPointNear(projector.toPixel({10.f, 10.f, 5.f}), {500.f, 0.f});
+    expectPointNear(projector.toPixel({5.f, 5.f, 5.f}), {250.f, 200.f});
+    // z does not affect the top view.
+    expectPointNear(projector.toPixel({5.f, 5.f, 0.f}), {250.f, 200.f});
+    expectPointNear(projector.toPixel({5.f, 5.f, 10.f}), {250.f, 200.f});
+  }
+
+  TEST("Front view: x maps across the width, z up the height") {
+    const cmp::Camera3D front_view(0.f, 0.f);
+    const cmp::Projector3D projector(linear_axes, front_view, graph_bounds);
+
+    expectPointNear(projector.toPixel({0.f, 5.f, 0.f}), {0.f, 400.f});
+    expectPointNear(projector.toPixel({10.f, 5.f, 10.f}), {500.f, 0.f});
+    expectPointNear(projector.toPixel({2.5f, 5.f, 7.5f}), {125.f, 100.f});
+    // y is the depth axis in the front view.
+    expectPointNear(projector.toPixel({2.5f, 0.f, 7.5f}), {125.f, 100.f});
+  }
+
+  TEST("Logarithmic z-axis is normalized in log space") {
+    const auto log_z_axes =
+        cmp::Axes3{{{0.f, 10.f}, cmp::Scaling::linear},
+                   {{0.f, 10.f}, cmp::Scaling::linear},
+                   {{1.f, 1000.f}, cmp::Scaling::logarithmic}};
+    const cmp::Camera3D front_view(0.f, 0.f);
+    const cmp::Projector3D projector(log_z_axes, front_view, graph_bounds);
+
+    // One decade per third of the graph height.
+    expectPointNear(projector.toPixel({5.f, 5.f, 1.f}), {250.f, 400.f});
+    expectPointNear(projector.toPixel({5.f, 5.f, 10.f}), {250.f, 400.f * 2.f / 3.f});
+    expectPointNear(projector.toPixel({5.f, 5.f, 100.f}), {250.f, 400.f / 3.f});
+    expectPointNear(projector.toPixel({5.f, 5.f, 1000.f}), {250.f, 0.f});
+  }
+
+  TEST("Default view: the data cube fills the graph bounds") {
+    const cmp::Projector3D projector(linear_axes, cmp::Camera3D(),
+                                     graph_bounds);
+
+    auto min_pixel = juce::Point<float>(1e9f, 1e9f);
+    auto max_pixel = juce::Point<float>(-1e9f, -1e9f);
+
+    for (const auto x : {0.f, 10.f}) {
+      for (const auto y : {0.f, 10.f}) {
+        for (const auto z : {0.f, 10.f}) {
+          const auto pixel = projector.toPixel({x, y, z});
+
+          min_pixel = {std::min(min_pixel.getX(), pixel.getX()),
+                       std::min(min_pixel.getY(), pixel.getY())};
+          max_pixel = {std::max(max_pixel.getX(), pixel.getX()),
+                       std::max(max_pixel.getY(), pixel.getY())};
+        }
+      }
+    }
+
+    expectPointNear(min_pixel, {0.f, 0.f});
+    expectPointNear(max_pixel, {500.f, 400.f});
+  }
+
+  TEST("updatePixelPoints projects all points") {
+    const std::vector<float> x_data = {0.f, 5.f, 10.f};
+    const std::vector<float> y_data = {0.f, 5.f, 10.f};
+    const std::vector<float> z_data = {0.f, 5.f, 10.f};
+
+    const cmp::Camera3D top_view(0.f, 90.f);
+    const cmp::Projector3D projector(linear_axes, top_view, graph_bounds);
+
+    cmp::PixelPoints pixel_points;
+    projector.updatePixelPoints(x_data, y_data, z_data, pixel_points);
+
+    expectEquals(pixel_points.size(), x_data.size());
+    expectPointNear(pixel_points[0], {0.f, 400.f});
+    expectPointNear(pixel_points[1], {250.f, 200.f});
+    expectPointNear(pixel_points[2], {500.f, 0.f});
+  }
+}
+;


### PR DESCRIPTION
## Summary

Phase 2 of the 3D plotting work: the pure math foundation for software 3D projection. Three small header-only classes, each fully unit-tested with no GUI dependency. Nothing here is wired into a component yet — that lands in Phase 3.

Builds on the dimension-agnostic primitives from Phase 1 (`Axis`, `AxisTransform`).

### What changed

- **`cmp_math3d.h`** — `Vec3<T>`/`Vec3f` (own type, not `juce::Vector3D`, to avoid a `juce_opengl` dependency) with dot/cross/length, plus `Axes3` bundling three `Axis_f`.
- **`cmp_camera3d.h`** — `Camera3D` following MATLAB's `view(az, el)`/`viewmtx` convention, default view `(-37.5°, 30°)`. Orthographic only; `toViewSpace` returns screen-right/screen-up/depth (depth reserved for painter's-algorithm sorting in a later phase). Distance/target deferred to the zoom/pan phase.
- **`cmp_projector3d.h`** — `Projector3D` normalizes the data cube into a centered unit cube (log axes in log space), rotates it via `Camera3D`, and stretches the view-space bounding box to fill the graph bounds (MATLAB 'stretch' camera mode), reusing `AxisTransform` for the view→pixel fit. Outputs graph-area-local `PixelPoints`, matching the 2D pipeline so all downstream drawing is reusable.

### Test coverage

- `cmp_math3d_test.cpp` — Vec3 dot/cross/length, Axes3 bundling
- `cmp_camera3d_test.cpp` — front/side/top views, MATLAB default-view unit-cube corner, azimuth periodicity, rotation length-invariance, `setView`
- `cmp_projector3d_test.cpp` — top/front views, log-z normalization, cube-fills-bounds in the default view, full `updatePixelPoints`

All tests pass (84 total in the suite).

### Design notes

Projection is done in software (data → model-view → 2D pixel points → existing `juce::Graphics` drawing), not OpenGL — this reuses the entire rendering back-half and works everywhere JUCE works. The math is kept in pure, header-level classes so correctness is checked by asserting where known cube corners land, no GUI required.

Foundation for Phase 3 (minimal working `Plot3D`: `GraphLine3D`, `Axes3DBox`, `plot3`).