### PR TITLE
Style: Apply clang-format (Google) across the codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/examples/example_apps/custom_colour/custom_colour.h
+++ b/examples/example_apps/custom_colour/custom_colour.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/fill/fill.h
+++ b/examples/example_apps/fill/fill.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/lim/lim.h
+++ b/examples/example_apps/lim/lim.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/loglog/loglog.h
+++ b/examples/example_apps/loglog/loglog.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/lookandfeel_timeline/lookandfeel_timeline.h
+++ b/examples/example_apps/lookandfeel_timeline/lookandfeel_timeline.h
@@ -5,10 +5,12 @@
  * https://opensource.org/licenses/MIT
  */
 
-#include "cmp_datamodels.h"
-#include <cmp_extras.hpp>
 #include <cmp_plot.h>
 #include <juce_gui_extra/juce_gui_extra.h>
+
+#include <cmp_extras.hpp>
+
+#include "cmp_datamodels.h"
 
 using namespace cmp;
 
@@ -30,7 +32,7 @@ class lookandfeel_timeline : public juce::Component {
     addAndMakeVisible(m_plot);
 
     // Plot some values.
-    m_plot.plot({{0, 3, 7, 9, 2.5}},{{-100, 20, 40, 50, 220}});
+    m_plot.plot({{0, 3, 7, 9, 2.5}}, {{-100, 20, 40, 50, 220}});
 
     // Setting x/y limes.
     m_plot.xLim(-10.f, 200.f);

--- a/examples/example_apps/marker/marker.h
+++ b/examples/example_apps/marker/marker.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/plot3d/plot3d.h
+++ b/examples/example_apps/plot3d/plot3d.h
@@ -17,8 +17,9 @@ class plot3d : public juce::Component {
   cmp::Plot3D m_plot_linear, m_plot_log;
 
  public:
-  plot3d() : m_plot_log(cmp::Scaling::linear, cmp::Scaling::linear,
-                          cmp::Scaling::logarithmic) {
+  plot3d()
+      : m_plot_log(cmp::Scaling::linear, cmp::Scaling::linear,
+                   cmp::Scaling::logarithmic) {
     setSize(1600, 800);
 
     // Add the plot objects as child components.

--- a/examples/example_apps/realtime/realtime.h
+++ b/examples/example_apps/realtime/realtime.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/semi_log_x/semi_log_x.h
+++ b/examples/example_apps/semi_log_x/semi_log_x.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/semi_log_y/semi_log_y.h
+++ b/examples/example_apps/semi_log_y/semi_log_y.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/examples/example_apps/simple/simple.h
+++ b/examples/example_apps/simple/simple.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
@@ -29,4 +29,4 @@ class simple : public juce::Component {
     m_plot.setBounds(getBounds());
   };
 };
-}
+}  // namespace examples

--- a/examples/example_apps/ticks/ticks.h
+++ b/examples/example_apps/ticks/ticks.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/extras/source/cmp_extras.cpp
+++ b/extras/source/cmp_extras.cpp
@@ -138,11 +138,10 @@ void PlotLookAndFeelTimeline::updateGridLabels(
 
     switch (direction) {
       case GridLine::Direction::vertical: {
-        const auto label =
-            use_custom_x_labels
-                ? getNextCustomLabel(custom_x_labels_reverse_it,
-                                     x_custom_label_ticks.rend())
-                : valueToStringWithoutTrailingZeros(tick);
+        const auto label = use_custom_x_labels
+                               ? getNextCustomLabel(custom_x_labels_reverse_it,
+                                                    x_custom_label_ticks.rend())
+                               : valueToStringWithoutTrailingZeros(tick);
 
         const auto [label_width, label_height] =
             getLabelWidthAndHeight(font, label);
@@ -152,8 +151,8 @@ void PlotLookAndFeelTimeline::updateGridLabels(
             is_x_axis_label_below_axes
                 ? common_plot_params.axes_bounds.getBottom() +
                       getXGridLabelDistanceFromAxesBound()
-                : common_plot_params.axes_bounds.getTopLeft().y -
-                      label_height - getMarginSmall() / 2;
+                : common_plot_params.axes_bounds.getTopLeft().y - label_height -
+                      getMarginSmall() / 2;
 
         const auto bound =
             juce::Rectangle<int>(int(position.x) - label_width / 2, bound_y,
@@ -163,11 +162,10 @@ void PlotLookAndFeelTimeline::updateGridLabels(
                                             x_axis_labels_out, label, bound);
       } break;
       case GridLine::Direction::horizontal: {
-        const auto label =
-            use_custom_y_labels
-                ? getNextCustomLabel(custom_y_labels_reverse_it,
-                                     y_custom_label_ticks.rend())
-                : valueToStringWithoutTrailingZeros(tick);
+        const auto label = use_custom_y_labels
+                               ? getNextCustomLabel(custom_y_labels_reverse_it,
+                                                    y_custom_label_ticks.rend())
+                               : valueToStringWithoutTrailingZeros(tick);
 
         const auto [label_width, label_height] =
             getLabelWidthAndHeight(font, label);

--- a/include/include/cmp_datamodels.h
+++ b/include/include/cmp_datamodels.h
@@ -27,8 +27,8 @@
 #endif
 
 #include <functional>
-#include <optional>
 #include <map>
+#include <optional>
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -490,15 +490,15 @@ struct SpreadIndex {
 /** @brief A view of the data required to draw a series */
 struct SeriesDataView {
   SeriesDataView(const std::vector<float>& _x_data,
-                    const std::vector<float>& _y_data,
-                    const PixelPoints& _pixel_points,
-                    const std::vector<std::size_t>& _pixel_point_indices,
-                    const SeriesAttribute& _series_attribute);
+                 const std::vector<float>& _y_data,
+                 const PixelPoints& _pixel_points,
+                 const std::vector<std::size_t>& _pixel_point_indices,
+                 const SeriesAttribute& _series_attribute);
 
   SeriesDataView(const Series& series);
   SeriesDataView(const std::vector<float>&&, const std::vector<float>&&,
-                    const PixelPoints&&,
-                    const std::vector<std::size_t>&&) =
+                 const PixelPoints&&,
+                 const std::vector<std::size_t>&&) =
       delete;  // prevents rvalue binding
 
   const std::vector<float>&x_data, &y_data;
@@ -604,7 +604,7 @@ template <typename T>
 class Observer {
  public:
   virtual void observableValueUpdated(ObserverId id, const T& newValue) = 0;
-  
+
   void detachFromObservable(ObserverId observableId) {
     auto it = m_observables.find(observableId);
     if (it != m_observables.end()) {
@@ -624,27 +624,27 @@ class Observer {
     }
   }
 
-  virtual ~Observer() {
-    detachFromAllObservables();
-  }
+  virtual ~Observer() { detachFromAllObservables(); }
 
  private:
   friend class Observable<T>;
-  void setObservable(Observable<T>* observable, ObserverId observableId, size_t observerId) {
+  void setObservable(Observable<T>* observable, ObserverId observableId,
+                     size_t observerId) {
     auto it = m_observables.find(observableId);
     if (it != m_observables.end()) {
       detachFromObservable(observableId);
     }
     m_observables[observableId] = std::make_pair(observable, observerId);
   }
-  
+
   std::map<ObserverId, std::pair<Observable<T>*, size_t>> m_observables;
 };
 
 template <typename T>
 class Observable {
  public:
-  Observable(ObserverId id, T value = T()) : id(id), value(value), next_observer_id(0) {}
+  Observable(ObserverId id, T value = T())
+      : id(id), value(value), next_observer_id(0) {}
 
   ~Observable() {
     auto observersCopy = observers;
@@ -670,16 +670,15 @@ class Observable {
   }
 
   void removeObserver(size_t observerId) {
-    auto it = std::find_if(observers.begin(), observers.end(),
-      [observerId](const auto& pair) {
-        return pair.first == observerId;
-      });
-    
+    auto it = std::find_if(
+        observers.begin(), observers.end(),
+        [observerId](const auto& pair) { return pair.first == observerId; });
+
     if (it != observers.end()) {
       observers.erase(it);
     }
   }
-  
+
   operator const T&() const { return value; }
   ObserverId getId() const { return id; }
   const T& getValue() const { return value; }
@@ -689,17 +688,18 @@ class Observable {
   ObserverId id;
   T value;
   size_t next_observer_id;
-  std::vector<std::pair<size_t, std::function<void(ObserverId, const T&)>>> observers;
+  std::vector<std::pair<size_t, std::function<void(ObserverId, const T&)>>>
+      observers;
 
   template <typename ObserverType>
   void addObserverInternal(ObserverType& observer) {
     size_t observerId = next_observer_id++;
     Observer<T>* baseObserver = &observer;
     baseObserver->setObservable(this, id, observerId);
-    observers.push_back(std::make_pair(observerId, 
-      [baseObserver](ObserverId id, const T& value) {
-        baseObserver->observableValueUpdated(id, value);
-      }));
+    observers.push_back(std::make_pair(
+        observerId, [baseObserver](ObserverId id, const T& value) {
+          baseObserver->observableValueUpdated(id, value);
+        }));
   }
 
   void notifyObservers() {

--- a/include/include/cmp_lookandfeel.h
+++ b/include/include/cmp_lookandfeel.h
@@ -88,7 +88,7 @@ class PlotLookAndFeel : public Plot::LookAndFeelMethods {
   juce::Font getTraceFont() const noexcept override;
 
   juce::Point<int> getTracePointPositionFrom(
-      const juce::Rectangle<int>& axes_bounds, const Lim<float> x_lim,
+      const juce::Rectangle<int> &axes_bounds, const Lim<float> x_lim,
       const Scaling x_scaling, const Lim<float> y_lim, const Scaling y_scaling,
       const juce::Point<float> series_values) const noexcept override;
 
@@ -108,7 +108,7 @@ class PlotLookAndFeel : public Plot::LookAndFeelMethods {
       UserInput user_input) const noexcept override;
 
   void drawSeries(juce::Graphics &g, const SeriesDataView series_data,
-                     const juce::Rectangle<int> &series_bounds) override;
+                  const juce::Rectangle<int> &series_bounds) override;
 
   void drawGridLabels(juce::Graphics &g, const LabelVector &x_axis_labels,
                       const LabelVector &y_axis_labels) override;
@@ -146,15 +146,15 @@ class PlotLookAndFeel : public Plot::LookAndFeelMethods {
 
   void updateXPixelPoints(
       const std::vector<std::size_t> &update_only_these_indices,
-      const Scaling x_scaling, const Lim<float> x_lim, const juce::Rectangle<int> &axes_bounds,
-      const std::vector<float> &x_data,
+      const Scaling x_scaling, const Lim<float> x_lim,
+      const juce::Rectangle<int> &axes_bounds, const std::vector<float> &x_data,
       std::vector<std::size_t> &pixel_points_indices,
       PixelPoints &pixel_points) noexcept override;
 
   void updateYPixelPoints(
       const std::vector<std::size_t> &update_only_these_indices,
-      const Scaling y_scaling, const Lim<float> y_lim, const juce::Rectangle<int> &axes_bounds,
-      const std::vector<float> &y_data,
+      const Scaling y_scaling, const Lim<float> y_lim,
+      const juce::Rectangle<int> &axes_bounds, const std::vector<float> &y_data,
       const std::vector<std::size_t> &pixel_points_indices,
       PixelPoints &pixel_points) noexcept override;
 

--- a/include/include/cmp_lookandfeel_base.h
+++ b/include/include/cmp_lookandfeel_base.h
@@ -23,7 +23,7 @@ namespace cmp {
  *   seen in \see cmp_lookandfeel.h
  */
 class PlotLookAndFeelBase : public juce::LookAndFeel_V4 {
-public:
+ public:
   virtual ~PlotLookAndFeelBase() = default;
 
   /** Draw background. */
@@ -35,9 +35,8 @@ public:
                          const juce::Rectangle<int> bounds) = 0;
 
   /** This method draws a single series. */
-  virtual void
-  drawSeries(juce::Graphics &g, const SeriesDataView series_data,
-                const juce::Rectangle<int> &series_bounds) = 0;
+  virtual void drawSeries(juce::Graphics &g, const SeriesDataView series_data,
+                          const juce::Rectangle<int> &series_bounds) = 0;
 
   /** This method draws the legend. */
   virtual void drawLegend(juce::Graphics &g,
@@ -45,9 +44,8 @@ public:
                           const juce::Rectangle<int> &bound) = 0;
 
   /** This method draws the legend background. */
-  virtual void
-  drawLegendBackground(juce::Graphics &g,
-                       const juce::Rectangle<int> &legend_bound) = 0;
+  virtual void drawLegendBackground(
+      juce::Graphics &g, const juce::Rectangle<int> &legend_bound) = 0;
 
   /** Draw a single trace point. */
   virtual void drawTraceLabel(juce::Graphics &g, const cmp::Label &x_label,
@@ -55,30 +53,29 @@ public:
                               const juce::Rectangle<int> bound) = 0;
 
   /** This method draws the trace label background. */
-  virtual void
-  drawTraceLabelBackground(juce::Graphics &g,
-                           const juce::Rectangle<int> &trace_label_bound) = 0;
+  virtual void drawTraceLabelBackground(
+      juce::Graphics &g, const juce::Rectangle<int> &trace_label_bound) = 0;
 
   /** Draw trace point. */
   virtual void drawTracePoint(juce::Graphics &g,
                               const juce::Rectangle<int> &bounds) = 0;
 
   /** This method draws the selection area (e.g. zoom area). */
-  virtual void
-  drawSelectionArea(juce::Graphics &g, juce::Point<int> &start_coordinates,
-                    const juce::Point<int> &end_coordinates,
-                    const juce::Rectangle<int> &axes_bounds) noexcept = 0;
+  virtual void drawSelectionArea(
+      juce::Graphics &g, juce::Point<int> &start_coordinates,
+      const juce::Point<int> &end_coordinates,
+      const juce::Rectangle<int> &axes_bounds) noexcept = 0;
 
   /** A method to find and get the colour from an id. */
-  virtual CONSTEXPR20 juce::Colour
-  findAndGetColourFromId(const int colour_id) const noexcept = 0;
+  virtual CONSTEXPR20 juce::Colour findAndGetColourFromId(
+      const int colour_id) const noexcept = 0;
 
   /** Returns the Font used for the Trace and Zoom buttons. */
   virtual CONSTEXPR20 juce::Font getButtonFont() const noexcept = 0;
 
   /** Returns the 'ColourIdsSeries' for a given index.*/
-  virtual CONSTEXPR20 int
-  getColourFromSeriesID(const std::size_t series_index) const = 0;
+  virtual CONSTEXPR20 int getColourFromSeriesID(
+      const std::size_t series_index) const = 0;
 
   /** Get the axes bounds, where the series and grids are to be drawn. A plot
    * component can be given to base the axes bounds on the grid anf axis
@@ -91,8 +88,8 @@ public:
   virtual CONSTEXPR20 juce::Font getGridLabelFont() const noexcept = 0;
 
   /** Get Maximum allowed characters for grid labels. */
-  virtual CONSTEXPR20 std::size_t
-  getMaximumAllowedCharacterGridLabel() const noexcept = 0;
+  virtual CONSTEXPR20 std::size_t getMaximumAllowedCharacterGridLabel()
+      const noexcept = 0;
 
   /** Get the legend position */
   virtual CONSTEXPR20 juce::Point<int> getLegendPosition(
@@ -119,8 +116,8 @@ public:
   /** Get the pixel distance a grid/tick label is pushed outside the series
    * bound it sits beside. Used by the 3D axes box to space its tick labels
    * away from the data cube. */
-  virtual CONSTEXPR20 int getGridLabelDistanceFromAxesBound() const noexcept =
-      0;
+  virtual CONSTEXPR20 int getGridLabelDistanceFromAxesBound()
+      const noexcept = 0;
 
   /** Get the pixel distance an axis title (the x/y/z label) is pushed outside
    * the axes bound, given the title's pixel height. Used by the 3D plot to
@@ -129,8 +126,8 @@ public:
       const int label_height) const noexcept = 0;
 
   /** Get the bounds of the componenet (Local bounds). */
-  virtual CONSTEXPR20 juce::Rectangle<int>
-  getPlotBounds(juce::Rectangle<int> bounds) const noexcept = 0;
+  virtual CONSTEXPR20 juce::Rectangle<int> getPlotBounds(
+      juce::Rectangle<int> bounds) const noexcept = 0;
 
   /** Get the Font used when drawing trace labels. */
   virtual CONSTEXPR20 juce::Font getTraceFont() const noexcept = 0;
@@ -142,8 +139,8 @@ public:
       const juce::Rectangle<int> &y_label_bounds) const noexcept = 0;
 
   /** Get the local bounds used when drawing the trace point.*/
-  virtual CONSTEXPR20 juce::Rectangle<int>
-  getTracePointLocalBounds() const noexcept = 0;
+  virtual CONSTEXPR20 juce::Rectangle<int> getTracePointLocalBounds()
+      const noexcept = 0;
 
   /** Get x and Y trace label bounds */
   virtual std::pair<juce::Rectangle<int>, juce::Rectangle<int>>
@@ -160,8 +157,8 @@ public:
   virtual CONSTEXPR20 juce::Font getXYTitleFont() const noexcept = 0;
 
   /** Get defualt user input map action. */
-  virtual std::map<UserInput, UserInputAction>
-  getDefaultUserInputMapAction() const noexcept = 0;
+  virtual std::map<UserInput, UserInputAction> getDefaultUserInputMapAction()
+      const noexcept = 0;
 
   /** Override the default user input map action. */
   virtual std::map<UserInput, UserInputAction> overrideUserInputMapAction(
@@ -169,8 +166,8 @@ public:
       const noexcept = 0;
 
   /** Get the user input action for a given user input. */
-  virtual UserInputAction
-  getUserInputAction(UserInput user_input) const noexcept = 0;
+  virtual UserInputAction getUserInputAction(
+      UserInput user_input) const noexcept = 0;
 
   /** Defines the default colours */
   virtual void setDefaultPlotColours() noexcept = 0;

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -2,9 +2,9 @@
  * @file cmp_plot.h
  * @brief Components for plotting 2-D lines and marker symbols
  * @ingroup CustomMatPlot
- * @details This file contains the Plot class and related components for creating
- *          2D plots with features like line plots, scatter plots, zooming, panning,
- *          and customizable axes.
+ * @details This file contains the Plot class and related components for
+ * creating 2D plots with features like line plots, scatter plots, zooming,
+ * panning, and customizable axes.
  * @author Frans Rosencrantz
  * @contact Frans.Rosencrantz@gmail.com
  */
@@ -22,7 +22,8 @@ namespace cmp {
 /**
  * @class Plot
  * @brief A component to plot 2-D lines/marker symbols
- * @details This class provides a flexible plotting component with features including:
+ * @details This class provides a flexible plotting component with features
+ * including:
  *          - Line and scatter plots
  *          - Tracing
  *          - Zooming and panning
@@ -30,11 +31,11 @@ namespace cmp {
  *          - Linear and logarithmic axis scaling
  *          - Legend support
  * @see SemiLogX
- * @see SemiLogY  
+ * @see SemiLogY
  * @see LogLog
  */
 class Plot : public juce::Component {
-public:
+ public:
   /** Destructor, making sure to set the lookandfeel in all subcomponenets to
    * nullptr. */
   ~Plot();
@@ -43,21 +44,21 @@ public:
   Plot(const Scaling x_scaling = Scaling::linear,
        const Scaling y_scaling = Scaling::linear);
 
-  /** 
+  /**
    * @brief Set the X-limits
    * @param min minimum value
    * @param max maximum value
    */
   void xLim(const float min, const float max);
 
-  /** 
+  /**
    * @brief Set the Y-limits
    * @param min minimum value
    * @param max maximum value
    */
   void yLim(const float min, const float max);
 
-  /** 
+  /**
    * @brief Plot y-data or y-data/x-data
    *
    * Plot y-data or y-data/x-data. Each vector in y-data represents a single
@@ -71,16 +72,18 @@ public:
    *
    * @param y_data vector of vectors with the y-values
    * @param x_data vector of vectors with the x-values
-   * @param series_attribute_list a list of series attributes @see SeriesAttribute
+   * @param series_attribute_list a list of series attributes @see
+   * SeriesAttribute
    */
   void plot(const std::vector<std::vector<float>> &y_data,
             const std::vector<std::vector<float>> &x_data = {},
             const SeriesAttributeList &series_attribute_list = {});
 
-  /** 
+  /**
    * @brief Draw horizontal line(s)
    *
-   * Draw horizontal line(s) at the given y-coordinates. Lines can be moved by dragging.
+   * Draw horizontal line(s) at the given y-coordinates. Lines can be moved by
+   * dragging.
    *
    * @param y_coordinates Y-coordinates where lines will be drawn
    * @param series_attributes Series attributes for the lines
@@ -91,7 +94,8 @@ public:
   /**
    * @brief Draw vertical line(s)
    *
-   * Draw vertical line(s) at the given x-coordinates. Lines can be moved by dragging.
+   * Draw vertical line(s) at the given x-coordinates. Lines can be moved by
+   * dragging.
    *
    * @param x_coordinates X-coordinates where lines will be drawn
    * @param series_attributes Series attributes for the lines
@@ -117,7 +121,8 @@ public:
    * 2. Call this function to fill area between specified lines
    *
    * @param spread_indices Indices of series to fill between
-   * @param fill_area_colours Colors for filled areas (uses ColourIdsSeries if empty)
+   * @param fill_area_colours Colors for filled areas (uses ColourIdsSeries if
+   * empty)
    */
   void fillBetween(const std::vector<SpreadIndex> &spread_indices,
                    const std::vector<juce::Colour> &fill_area_colours = {});
@@ -160,19 +165,19 @@ public:
   void setSeriesDataChangedCallback(
       SeriesChangedCallback series_changed_callback);
 
-  /** 
+  /**
    * @brief Set the text for label on the X-axis
    * @param x_label text to be displayed on the x-axis
    */
   void setXLabel(const std::string &x_label);
 
-  /** 
+  /**
    * @brief Set the text for label on the Y-axis
    * @param y_label text to be displayed on the y-axis
    */
   void setYLabel(const std::string &y_label);
 
-  /** 
+  /**
    * @brief Set x & y-axis scaling
    * @param x_scaling x-axis scaling
    * @param y_scaling y-axis scaling
@@ -180,13 +185,13 @@ public:
    */
   void setScaling(Scaling x_scaling, Scaling y_scaling) noexcept;
 
-  /** 
+  /**
    * @brief Set the text for title label
    * @param title text to be displayed as the title
    */
   void setTitle(const std::string &title);
 
-  /** 
+  /**
    * @brief Set trace-point
    *
    * Set a trace-point to the point on a series closest the given
@@ -197,7 +202,7 @@ public:
    */
   void setTracePoint(const juce::Point<float> &trace_point_coordinate);
 
-  /** 
+  /**
    * @brief Set the text for grid labels on the x-axis
    *
    * Set custom text for the grid labels and overrides the labels made based
@@ -255,8 +260,8 @@ public:
   /** @brief Set Legend
    *
    *  Set descriptions for each series. The label 'label1..N' will be used if
-   *  fewers numbers of series_descriptions are provided than existing numbers of
-   *  series.
+   *  fewers numbers of series_descriptions are provided than existing numbers
+   * of series.
    *
    *  @param series_descriptions description of the series
    *  @return void.
@@ -279,11 +284,12 @@ public:
   //==============================================================================
 
   /** @brief Color IDs for customizing plot appearance
-   * @details These IDs can be used with Component::setColour() or LookAndFeel::setColour()
-   *          to customize colors of various plot elements.
-   * @note All color IDs should be passed to setColour() along with the desired Color value
+   * @details These IDs can be used with Component::setColour() or
+   * LookAndFeel::setColour() to customize colors of various plot elements.
+   * @note All color IDs should be passed to setColour() along with the desired
+   * Color value
    * @see Component::setColour
-   * @see Component::findColour  
+   * @see Component::findColour
    * @see LookAndFeel::setColour
    */
   enum ColourIds : int {
@@ -325,7 +331,7 @@ public:
    *   The default implementation can be seen in \see cmp_lookandfeelmethods.h
    */
   class LookAndFeelMethods : public PlotLookAndFeelBase {
-  public:
+   public:
     virtual ~LookAndFeelMethods() = default;
 
     /** This method draws the labels on the x and y axis. */
@@ -350,20 +356,19 @@ public:
         const juce::Point<float> series_values) const noexcept = 0;
 
     /** Get distance from left of grid x-labels to right side of axes bound. */
-    virtual CONSTEXPR20 int
-    getXGridLabelDistanceFromAxesBound() const noexcept = 0;
+    virtual CONSTEXPR20 int getXGridLabelDistanceFromAxesBound()
+        const noexcept = 0;
 
     /** Get distance from top of grid x-labels to bottom of axes bound. */
     virtual CONSTEXPR20 int getYGridLabelDistanceFromAxesBound(
         const int y_grid_label_width) const noexcept = 0;
 
     /** Updates the x-ticks with auto generated ticks. */
-    virtual void
-    updateVerticalGridLineTicksAuto(const juce::Rectangle<int> &bounds,
-                                    const Lim_f &x_lim, const Scaling x_scaling,
-                                    const GridType grid_type,
-                                    const std::vector<float> &previous_ticks,
-                                    std::vector<float> &x_ticks) noexcept = 0;
+    virtual void updateVerticalGridLineTicksAuto(
+        const juce::Rectangle<int> &bounds, const Lim_f &x_lim,
+        const Scaling x_scaling, const GridType grid_type,
+        const std::vector<float> &previous_ticks,
+        std::vector<float> &x_ticks) noexcept = 0;
 
     /** Updates the y-ticks with auto generated ticks. */
     virtual void updateHorizontalGridLineTicksAuto(
@@ -424,23 +429,22 @@ public:
   /** @internal */
   void mouseUp(const juce::MouseEvent &event) override;
   /** @internal */
-  juce::Point<float>
-  getMousePositionRelativeToAxesArea(const juce::MouseEvent &event) const;
+  juce::Point<float> getMousePositionRelativeToAxesArea(
+      const juce::MouseEvent &event) const;
   /** @internal */
   void modifierKeysChanged(const juce::ModifierKeys &modifiers) override;
 
-private:
+ private:
   /** @internal */
   template <bool is_point_data_point = false>
-  std::tuple<size_t, const Series *>
-  findNearestPoint(juce::Point<float> point,
-                   const Series *series = nullptr);
+  std::tuple<size_t, const Series *> findNearestPoint(
+      juce::Point<float> point, const Series *series = nullptr);
   /** @internal */
   PlotLookAndFeel *getDefaultLookAndFeel();
   /** @internal */
   template <SeriesType t_series_type>
   void addSeriesInternal(std::unique_ptr<Series> &series,
-                            const size_t series_index);
+                         const size_t series_index);
   /** @internal */
   void resizeChildrens();
   /** @internal */
@@ -448,7 +452,7 @@ private:
   /** @internal */
   template <SeriesType t_series_type>
   void updateSeriesYData(const std::vector<std::vector<float>> &y_data,
-                            const SeriesAttributeList &series_attribute_list);
+                         const SeriesAttributeList &series_attribute_list);
   /** @internal */
   template <SeriesType t_series_type>
   void updateSeriesXData(const std::vector<std::vector<float>> &x_data);
@@ -472,8 +476,8 @@ private:
                     const SeriesAttributeList &series_attributes,
                     const bool update_y_data_only = false);
   /** @internal */
-  std::vector<std::vector<float>>
-  generateXdataRamp(const std::vector<std::vector<float>> &y_data);
+  std::vector<std::vector<float>> generateXdataRamp(
+      const std::vector<std::vector<float>> &y_data);
   /** @internal */
   void syncDownsamplingModeWithMoveType();
   /** @internal */
@@ -539,8 +543,8 @@ private:
 
   /** Friend functions */
   friend const AreLabelsSet areLabelsSet(const Plot *plot) noexcept;
-  friend const std::pair<int, int>
-  getMaxGridLabelWidth(const Plot *plot) noexcept;
+  friend const std::pair<int, int> getMaxGridLabelWidth(
+      const Plot *plot) noexcept;
 
   /** Other variables */
   PixelPointMoveType m_pixel_point_move_type{PixelPointMoveType::none};
@@ -552,34 +556,35 @@ private:
 /**
  * @class SemiLogX
  * @brief Plot with logarithmic x-axis and linear y-axis scaling
- * @details Convenience class that creates a Plot with logarithmic x-axis scaling.
- *          Useful for data that spans multiple orders of magnitude in x.
+ * @details Convenience class that creates a Plot with logarithmic x-axis
+ * scaling. Useful for data that spans multiple orders of magnitude in x.
  */
 class SemiLogX : public Plot {
-public:
+ public:
   SemiLogX() : Plot(Scaling::logarithmic){};
 };
 
 /**
  * @class SemiLogY
- * @brief Plot with linear x-axis and logarithmic y-axis scaling  
- * @details Convenience class that creates a Plot with logarithmic y-axis scaling.
- *          Useful for data that spans multiple orders of magnitude in y.
+ * @brief Plot with linear x-axis and logarithmic y-axis scaling
+ * @details Convenience class that creates a Plot with logarithmic y-axis
+ * scaling. Useful for data that spans multiple orders of magnitude in y.
  */
 class SemiLogY : public Plot {
-public:
+ public:
   SemiLogY() : Plot(Scaling::linear, Scaling::logarithmic){};
 };
 
 /**
  * @class LogLog
  * @brief Plot with logarithmic scaling on both axes
- * @details Convenience class that creates a Plot with logarithmic scaling on both axes.
- *          Useful for data that spans multiple orders of magnitude in both dimensions.
+ * @details Convenience class that creates a Plot with logarithmic scaling on
+ * both axes. Useful for data that spans multiple orders of magnitude in both
+ * dimensions.
  */
 class LogLog : public Plot {
-public:
+ public:
   LogLog() : Plot(Scaling::logarithmic, Scaling::logarithmic){};
 };
 
-} // namespace cmp
+}  // namespace cmp

--- a/include/include/cmp_plot3d.h
+++ b/include/include/cmp_plot3d.h
@@ -33,7 +33,7 @@ class Axes3DBox;
  * @see Plot
  */
 class Plot3D : public juce::Component {
-public:
+ public:
   /** Destructor, making sure to set the lookandfeel in all subcomponenets to
    * nullptr. */
   ~Plot3D() override;
@@ -135,7 +135,7 @@ public:
   /** @internal */
   void lookAndFeelChanged() override;
 
-private:
+ private:
   /** @internal */
   void resizeChildrens();
   /** @internal */

--- a/include/include_internal/cmp_axes3dbox.h
+++ b/include/include_internal/cmp_axes3dbox.h
@@ -85,9 +85,8 @@ inline bool isBackFace(const CubeFace face, const Camera3D& camera) noexcept {
 inline std::vector<CubeFace> selectBackFaces(const Camera3D& camera) {
   auto back_faces = std::vector<CubeFace>();
 
-  for (const auto face :
-       {CubeFace::x_min, CubeFace::x_max, CubeFace::y_min, CubeFace::y_max,
-        CubeFace::z_min, CubeFace::z_max}) {
+  for (const auto face : {CubeFace::x_min, CubeFace::x_max, CubeFace::y_min,
+                          CubeFace::y_max, CubeFace::z_min, CubeFace::z_max}) {
     if (isBackFace(face, camera)) back_faces.push_back(face);
   }
 
@@ -120,10 +119,10 @@ inline CubeFace getTickLabelZFace(const Camera3D& camera) noexcept {
  * z-axis. Returns {x-side face, y-side face}. */
 inline std::pair<CubeFace, CubeFace> getZTickLabelEdge(
     const Camera3D& camera) noexcept {
-  const auto x_face = isBackFace(CubeFace::x_min, camera) ? CubeFace::x_max
-                                                          : CubeFace::x_min;
-  const auto y_face = isBackFace(CubeFace::y_max, camera) ? CubeFace::y_max
-                                                          : CubeFace::y_min;
+  const auto x_face =
+      isBackFace(CubeFace::x_min, camera) ? CubeFace::x_max : CubeFace::x_min;
+  const auto y_face =
+      isBackFace(CubeFace::y_max, camera) ? CubeFace::y_max : CubeFace::y_min;
 
   return {x_face, y_face};
 }

--- a/include/include_internal/cmp_camera3d.h
+++ b/include/include_internal/cmp_camera3d.h
@@ -41,7 +41,8 @@ class Camera3D {
 
   /** @brief Construct a camera with the given azimuth and elevation, like
    * MATLAB's view(az, el). */
-  Camera3D(const float azimuth_degrees, const float elevation_degrees) noexcept {
+  Camera3D(const float azimuth_degrees,
+           const float elevation_degrees) noexcept {
     setView(azimuth_degrees, elevation_degrees);
   }
 

--- a/include/include_internal/cmp_downsampler.h
+++ b/include/include_internal/cmp_downsampler.h
@@ -48,9 +48,11 @@ class Downsampler {
    *  @param x_based_idxs_out the output x-indices.
    *  @return void.
    */
-  static void calculateXIndices(const Scaling x_scaling, const Lim<FloatType> x_lim, const juce::Rectangle<int> &axes_bounds,
-                                    const std::vector<FloatType> &x_data,
-                                    std::vector<std::size_t> &x_idxs);
+  static void calculateXIndices(const Scaling x_scaling,
+                                const Lim<FloatType> x_lim,
+                                const juce::Rectangle<int> &axes_bounds,
+                                const std::vector<FloatType> &x_data,
+                                std::vector<std::size_t> &x_idxs);
 
   /** @brief Calculate xy-indices
    *
@@ -64,8 +66,8 @@ class Downsampler {
    *  @param xy_based_idxs_out indices used to downsample the data.
    *  @return void.
    */
-  static void calculateXYBasedIdxs(
-      const std::vector<std::size_t> &x_idxs,
-      const std::vector<FloatType> &y_data, std::vector<std::size_t> &xy_idxs);
+  static void calculateXYBasedIdxs(const std::vector<std::size_t> &x_idxs,
+                                   const std::vector<FloatType> &y_data,
+                                   std::vector<std::size_t> &xy_idxs);
 };
 }  // namespace cmp

--- a/include/include_internal/cmp_frame.h
+++ b/include/include_internal/cmp_frame.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/include/include_internal/cmp_grid.h
+++ b/include/include_internal/cmp_grid.h
@@ -30,9 +30,9 @@ namespace cmp {
  * Grid class implementation of grid component
  *
  * Componenet for creating grids and grid labels. The idea with this componenet
- * is to create the grids behind the actual series(s) together with series labels
- * outside the axes area. It can also be used to only create the grid labels
- * without the grids.
+ * is to create the grids behind the actual series(s) together with series
+ * labels outside the axes area. It can also be used to only create the grid
+ * labels without the grids.
  *
  */
 class Grid : public juce::Component,
@@ -41,7 +41,6 @@ class Grid : public juce::Component,
              public virtual Observer<Lim_f>,
              public virtual Observer<bool> {
  public:
-
   /** @brief Enables grid or tiny grid
    *
    *  Turn on grids or tiny grids. @see GridType in cmp:datamodels.h.

--- a/include/include_internal/cmp_label.h
+++ b/include/include_internal/cmp_label.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/include/include_internal/cmp_projector3d.h
+++ b/include/include_internal/cmp_projector3d.h
@@ -42,13 +42,13 @@ class Projector3D {
  public:
   Projector3D(const Axes3& axes, const Camera3D& camera,
               const juce::Rectangle<int>& axes_bounds) noexcept
-      : Projector3D(axes, camera, axes_bounds, viewSpaceBoundingBox(camera)) {
-  }
+      : Projector3D(axes, camera, axes_bounds, viewSpaceBoundingBox(camera)) {}
 
   /** @brief Project a single data point to its axes-area-local pixel
    * point. */
   juce::Point<float> toPixel(const Vec3f& data_point) const noexcept {
-    const auto view_point = m_camera.toViewSpace(toCenteredUnitCube(data_point));
+    const auto view_point =
+        m_camera.toViewSpace(toCenteredUnitCube(data_point));
 
     return {m_screen_x.toPixel(view_point.x), m_screen_y.toPixel(view_point.y)};
   }
@@ -61,8 +61,7 @@ class Projector3D {
                          PixelPoints& pixel_points) const {
     // The x/y/z data must be equal length; the caller (the public plot3 API)
     // guarantees this. There is a bug in the code if this assert happens.
-    jassert(x_data.size() == y_data.size() &&
-            y_data.size() == z_data.size());
+    jassert(x_data.size() == y_data.size() && y_data.size() == z_data.size());
 
     pixel_points.resize(x_data.size());
 
@@ -77,12 +76,14 @@ class Projector3D {
               const std::pair<Lim_f, Lim_f>& view_bounding_box) noexcept
       : m_axes{axes},
         m_camera{camera},
-        m_screen_x{{view_bounding_box.first, Scaling::linear}, 0.0f,
+        m_screen_x{{view_bounding_box.first, Scaling::linear},
+                   0.0f,
                    static_cast<float>(axes_bounds.getWidth())},
         // The y-axis is inverted: the bottom of the view-space bounding box
         // maps to the series-area height.
         m_screen_y{{view_bounding_box.second, Scaling::linear},
-                   static_cast<float>(axes_bounds.getHeight()), 0.0f} {}
+                   static_cast<float>(axes_bounds.getHeight()),
+                   0.0f} {}
 
   /** Normalize a value into [0, 1] along one axis. */
   static float toUnitRange(const float value, const Axis_f& axis) noexcept {

--- a/include/include_internal/cmp_selection_area.h
+++ b/include/include_internal/cmp_selection_area.h
@@ -31,9 +31,9 @@ namespace cmp {
  * move a trace point.
  */
 class SelectionArea : public juce::Component,
-                  public virtual Observer<Lim<float>>,
-                  public virtual Observer<Scaling> {
-public:
+                      public virtual Observer<Lim<float>>,
+                      public virtual Observer<Scaling> {
+ public:
   /** @brief Get the start postion.
    *
    *  Get the start postion.
@@ -110,7 +110,8 @@ public:
    *  @param id the observer id.
    *  @param new_value the new value.
    */
-  void observableValueUpdated(ObserverId id, const Lim<float>& new_value) override;
+  void observableValueUpdated(ObserverId id,
+                              const Lim<float> &new_value) override;
 
   /** @brief Observer function for scaling.
    *
@@ -128,7 +129,7 @@ public:
   /** @internal */
   void lookAndFeelChanged() override;
 
-private:
+ private:
   juce::LookAndFeel *m_lookandfeel = nullptr;
 
   juce::Point<int> m_start_pos, m_end_pos;
@@ -139,4 +140,4 @@ private:
 
   const CommonPlotParameterView *m_common_plot_params;
 };
-} // namespace cmp
+}  // namespace cmp

--- a/include/include_internal/cmp_series.h
+++ b/include/include_internal/cmp_series.h
@@ -34,12 +34,12 @@ namespace cmp {
  *  a subcomponenet to cmp::Plot.
  */
 class Series : public juce::Component,
-                  public virtual Observer<Scaling>,
-                  public virtual Observer<Lim<float>>,
-                  public virtual Observer<juce::Rectangle<int>>,
-                  public virtual Observer<DownsamplingType>,
-                  public virtual Observer<bool> {
-public:
+               public virtual Observer<Scaling>,
+               public virtual Observer<Lim<float>>,
+               public virtual Observer<juce::Rectangle<int>>,
+               public virtual Observer<DownsamplingType>,
+               public virtual Observer<bool> {
+ public:
   /** @brief Find closest point on series from pixel point.
    *
    * @param this_pixel_point the point on the series.
@@ -249,7 +249,8 @@ public:
    * @param new_value the new value of the observer.
    * @return void.
    */
-  void observableValueUpdated(ObserverId id, const Lim<float>& new_value) override;
+  void observableValueUpdated(ObserverId id,
+                              const Lim<float>& new_value) override;
 
   /** @brief Observer function for axes bounds.
    *
@@ -257,7 +258,8 @@ public:
    * @param new_value the new value of the observer.
    * @return void.
    */
-  void observableValueUpdated(ObserverId id, const juce::Rectangle<int>& new_value) override;
+  void observableValueUpdated(ObserverId id,
+                              const juce::Rectangle<int>& new_value) override;
 
   /** @brief Observer function for downsampling type.
    *
@@ -265,7 +267,8 @@ public:
    * @param new_value the new value of the observer.
    * @return void.
    */
-  void observableValueUpdated(ObserverId id, const DownsamplingType& new_value) override;
+  void observableValueUpdated(ObserverId id,
+                              const DownsamplingType& new_value) override;
 
   /** @brief Observer function for notify components on update.
    *
@@ -291,7 +294,8 @@ public:
       const std::vector<size_t>& update_only_these_indices);
 
   std::vector<float> m_x_data, m_y_data;
-  std::vector<std::size_t> m_x_based_ds_indices, m_xy_indices, m_indices_to_update;
+  std::vector<std::size_t> m_x_based_ds_indices, m_xy_indices,
+      m_indices_to_update;
   PixelPoints m_pixel_points;
   SeriesType m_series_type{SeriesType::normal};
 
@@ -308,7 +312,6 @@ public:
  *  \brief a class to hold a list of series.
  */
 struct SeriesList : public std::vector<std::unique_ptr<Series>> {
-
   /** @brief Get the number of series for a specific type.
    *
    * @tparam t_series_type the type of series.
@@ -318,7 +321,7 @@ struct SeriesList : public std::vector<std::unique_ptr<Series>> {
   size_t size() const noexcept;
 
   /** @brief Resize the number of series for a specific type.
-   * 
+   *
    * @tparam t_series_type the type of series.
    * @param new_size the new size of the series list.
    * @return void.
@@ -343,7 +346,7 @@ struct Spread : public juce::Component {
    * @param lower_bound series that decribes the lower boundary.
    */
   Spread(const Series* upper_bound, const Series* lower_bound,
-              const juce::Colour spread_colour)
+         const juce::Colour spread_colour)
       : m_upper_bound{upper_bound},
         m_lower_bound{lower_bound},
         m_spread_colour{spread_colour} {}

--- a/include/include_internal/cmp_trace.h
+++ b/include/include_internal/cmp_trace.h
@@ -38,8 +38,7 @@ enum class TraceLabelCornerPosition {
 /** @brief A struct that defines a tracepoint. */
 template <class ValueType>
 struct TracePoint : public juce::Component {
-  explicit TracePoint(const size_t data_point_index,
-                      const Series* series)
+  explicit TracePoint(const size_t data_point_index, const Series* series)
       : data_point_index(data_point_index), associated_series(series){};
 
   constexpr bool operator==(const TracePoint<ValueType>& rhs) {
@@ -178,7 +177,7 @@ class Trace : public virtual Observer<Lim<float>>,
               public virtual Observer<Scaling>,
               public virtual Observer<juce::Rectangle<int>>,
               public virtual Observer<bool> {
-public:
+ public:
   /** Destructor. Setting lookandfeel to nullptr. */
   ~Trace();
 
@@ -195,8 +194,7 @@ public:
    * @param TracePoint juce::Componenet* a TracePoint component.
    * @return Series* the associated Series if found else nullptr
    */
-  const Series* getAssociatedSeries(
-      const juce::Component* trace_point) const;
+  const Series* getAssociatedSeries(const juce::Component* trace_point) const;
 
   /** @brief Get the data position for a tracepoint or trace label.
    *
@@ -232,8 +230,7 @@ public:
    * @param trace_point_visibility the visibility of the tracepoint.
    * @return void.
    */
-  void addTracePoint(const Series* series,
-                     const size_t pixel_point_index,
+  void addTracePoint(const Series* series, const size_t pixel_point_index,
                      const TracePointVisibilityType trace_point_visibility);
 
   /** @brief Get tracepoint from juce::component.
@@ -289,8 +286,7 @@ public:
    * @return true if the value was changed.
    */
   bool setDataPointFor(juce::Component* trace_point,
-                       const size_t pixel_point_index,
-                       const Series* series);
+                       const size_t pixel_point_index, const Series* series);
 
   /** @brief Set the coner position of a single tracelabel.
    *
@@ -339,7 +335,8 @@ public:
    * @param id the observer id.
    * @param new_value the new value.
    */
-  void observableValueUpdated(ObserverId id, const Lim<float>& new_value) override;
+  void observableValueUpdated(ObserverId id,
+                              const Lim<float>& new_value) override;
 
   /** @brief Observer function for scaling.
    *
@@ -353,7 +350,8 @@ public:
    * @param id the observer id.
    * @param new_value the new value.
    */
-  void observableValueUpdated(ObserverId id, const juce::Rectangle<int>& new_value) override;
+  void observableValueUpdated(ObserverId id,
+                              const juce::Rectangle<int>& new_value) override;
 
   /** @brief Observer function for boolean values.
    *

--- a/include/include_internal/cmp_utils.h
+++ b/include/include_internal/cmp_utils.h
@@ -84,8 +84,7 @@ struct AreLabelsSet {
 
 /*============================================================================*/
 
-static SeriesDataViewList createSeriesDataViewList(
-    const SeriesVector& series) {
+static SeriesDataViewList createSeriesDataViewList(const SeriesVector& series) {
   SeriesDataViewList series_data_view_list;
   series_data_view_list.reserve(series.size());
 
@@ -122,13 +121,13 @@ constexpr float getYDataFromYPixelCoordinate(
 }
 
 static juce::Point<float> getDataPointFromPixelCoordinate(
-    const juce::Point<float> pos,
-    const juce::Rectangle<float>& axes_bounds, const Lim_f x_lim,
-    const Scaling x_scaling, const Lim_f y_lim, const Scaling y_scaling) noexcept {
-  const auto x = getXDataFromXPixelCoordinate(
-      pos.getX(), axes_bounds, x_lim, x_scaling);
-  const auto y = getYDataFromYPixelCoordinate(
-      pos.getY(), axes_bounds, y_lim, y_scaling);
+    const juce::Point<float> pos, const juce::Rectangle<float>& axes_bounds,
+    const Lim_f x_lim, const Scaling x_scaling, const Lim_f y_lim,
+    const Scaling y_scaling) noexcept {
+  const auto x =
+      getXDataFromXPixelCoordinate(pos.getX(), axes_bounds, x_lim, x_scaling);
+  const auto y =
+      getYDataFromYPixelCoordinate(pos.getY(), axes_bounds, y_lim, y_scaling);
 
   return juce::Point<float>(x, y);
 }

--- a/source/cmp_axes3dbox.cpp
+++ b/source/cmp_axes3dbox.cpp
@@ -62,7 +62,8 @@ static std::vector<float> generateAxisGridLines(const Axis_f& axis) {
     const auto decade_value = std::pow(10.0f, decade);
     for (int n = 1; n <= 9; ++n) {
       const auto value = static_cast<float>(n) * decade_value;
-      if (value >= axis.lim.min && value <= axis.lim.max) lines.push_back(value);
+      if (value >= axis.lim.min && value <= axis.lim.max)
+        lines.push_back(value);
     }
   }
 
@@ -229,9 +230,12 @@ void Axes3DBox::paint(juce::Graphics& g) {
 
   g.setFont(lnf->getGridLabelFont());
 
-  const auto x_label_y_value = getFaceValue(getXTickLabelYFace(m_camera), m_axes);
-  const auto y_label_x_value = getFaceValue(getYTickLabelXFace(m_camera), m_axes);
-  const auto xy_label_z_value = getFaceValue(getTickLabelZFace(m_camera), m_axes);
+  const auto x_label_y_value =
+      getFaceValue(getXTickLabelYFace(m_camera), m_axes);
+  const auto y_label_x_value =
+      getFaceValue(getYTickLabelXFace(m_camera), m_axes);
+  const auto xy_label_z_value =
+      getFaceValue(getTickLabelZFace(m_camera), m_axes);
   const auto z_label_edge = getZTickLabelEdge(m_camera);
   const auto z_label_x_value = getFaceValue(z_label_edge.first, m_axes);
   const auto z_label_y_value = getFaceValue(z_label_edge.second, m_axes);

--- a/source/cmp_downsampler.cpp
+++ b/source/cmp_downsampler.cpp
@@ -15,126 +15,128 @@
 
 namespace cmp {
 namespace {
-    constexpr size_t MIN_POINTS_FOR_DOWNSAMPLING = 100u;
-    constexpr size_t MAX_POINTS_PER_PIXEL = 3u;
-    constexpr int PADDING_POINTS = 2;  // Number of points to add outside visible range
-    constexpr bool COMPUTE_ALL_POINTS = false;
+constexpr size_t MIN_POINTS_FOR_DOWNSAMPLING = 100u;
+constexpr size_t MAX_POINTS_PER_PIXEL = 3u;
+constexpr int PADDING_POINTS =
+    2;  // Number of points to add outside visible range
+constexpr bool COMPUTE_ALL_POINTS = false;
 
-    template <class FloatType>
-    struct MinMaxIndices {
-        size_t min_idx;
-        size_t max_idx;
-        FloatType min_val;
-        FloatType max_val;
-    };
+template <class FloatType>
+struct MinMaxIndices {
+  size_t min_idx;
+  size_t max_idx;
+  FloatType min_val;
+  FloatType max_val;
+};
 
-    template<class FloatType>
-    MinMaxIndices<FloatType> findMinMaxIndices(const std::vector<FloatType>& y_data, 
-                                   size_t start_idx, 
-                                   size_t end_idx) {
-        MinMaxIndices<FloatType> result{start_idx, start_idx, y_data[start_idx], y_data[start_idx]};
-        
-        for (auto idx = start_idx + 1; idx < end_idx; ++idx) {
-            auto y_value = y_data[idx];
-            if (y_value < result.min_val) {
-                result.min_val = y_value;
-                result.min_idx = idx;
-            } else if (y_value > result.max_val) {
-                result.max_val = y_value;
-                result.max_idx = idx;
-            }
-        }
-        return result;
+template <class FloatType>
+MinMaxIndices<FloatType> findMinMaxIndices(const std::vector<FloatType>& y_data,
+                                           size_t start_idx, size_t end_idx) {
+  MinMaxIndices<FloatType> result{start_idx, start_idx, y_data[start_idx],
+                                  y_data[start_idx]};
+
+  for (auto idx = start_idx + 1; idx < end_idx; ++idx) {
+    auto y_value = y_data[idx];
+    if (y_value < result.min_val) {
+      result.min_val = y_value;
+      result.min_idx = idx;
+    } else if (y_value > result.max_val) {
+      result.max_val = y_value;
+      result.max_idx = idx;
     }
-
-    template <class ValueType>
-    struct XRangeIndices {
-        size_t start_idx;
-        size_t end_idx;
-    };
-
-    template <class ValueType>
-    XRangeIndices<ValueType> findDataRange(const ValueType x_min_lim,
-                                          const ValueType x_max_lim,
-                                          const std::vector<ValueType>& x_data) {
-        if (x_data.empty()) {
-            return {0u, 0u};
-        }
-
-        // Find start index, ensuring we don't underflow
-        const auto raw_start = std::distance(x_data.begin(), 
-            std::lower_bound(x_data.begin(), x_data.end(), x_min_lim));
-        const auto padded_start = std::max(0L, static_cast<long>(raw_start - PADDING_POINTS));
-        const auto start_idx = static_cast<size_t>(padded_start);
-
-        // Find end index, ensuring we don't overflow
-        const auto raw_end = std::distance(x_data.begin(),
-            std::upper_bound(x_data.begin(), x_data.end(), x_max_lim));
-        const auto max_size = static_cast<long>(x_data.size() - 1);
-        const auto padded_end = std::min(max_size, static_cast<long>(raw_end + PADDING_POINTS));
-        const auto end_idx = static_cast<size_t>(padded_end);
-
-        return XRangeIndices<ValueType>{start_idx, end_idx};
-    }
-
-    template <class ValueType>
-    bool shouldAddPoint(const ValueType current_value, 
-                       const ValueType last_value,
-                       const ValueType min_distance,
-                       const ValueType prev_difference,
-                       const ValueType current_difference) {
-        // Add point if direction changes or distance exceeds threshold
-        const bool direction_changed = (std::signbit(prev_difference) != 
-                                      std::signbit(current_difference));
-        const bool exceeds_distance = (std::abs(last_value - current_value) > 
-                                     min_distance);
-        return direction_changed || exceeds_distance;
-    }
-
-    template <class FloatType>
-    struct PixelColumnData {
-        std::vector<size_t> indices;
-        FloatType min_val;
-        FloatType max_val;
-        size_t min_idx;
-        size_t max_idx;
-    };
-
-    template <class FloatType>
-    void processPixelColumn(const std::vector<FloatType>& y_data,
-                           size_t start_idx,
-                           size_t end_idx,
-                           fast_vector<std::size_t>& xy_indices) {
-        if (end_idx - start_idx <= MAX_POINTS_PER_PIXEL) {
-            // For small segments, include all points
-            for (auto i = start_idx; i < end_idx; ++i) {
-                xy_indices.push_back(i);
-            }
-            return;
-        }
-
-        // Find min/max points in this column
-        auto [min_idx, max_idx, min_val, max_val] = 
-            findMinMaxIndices(y_data, start_idx, end_idx);
-
-        // Always include the start point
-        xy_indices.push_back(start_idx);
-
-        // Add min/max points in order of appearance
-        if (min_idx < max_idx) {
-            xy_indices.push_back_if_not_in_back(min_idx);
-            xy_indices.push_back_if_not_in_back(max_idx);
-        } else {
-            xy_indices.push_back_if_not_in_back(max_idx);
-            xy_indices.push_back_if_not_in_back(min_idx);
-        }
-
-        // Include end point if it's significant
-        if (end_idx - 1 != max_idx && end_idx - 1 != min_idx) {
-            xy_indices.push_back_if_not_in_back(end_idx - 1);
-        }
-    }
+  }
+  return result;
 }
+
+template <class ValueType>
+struct XRangeIndices {
+  size_t start_idx;
+  size_t end_idx;
+};
+
+template <class ValueType>
+XRangeIndices<ValueType> findDataRange(const ValueType x_min_lim,
+                                       const ValueType x_max_lim,
+                                       const std::vector<ValueType>& x_data) {
+  if (x_data.empty()) {
+    return {0u, 0u};
+  }
+
+  // Find start index, ensuring we don't underflow
+  const auto raw_start =
+      std::distance(x_data.begin(),
+                    std::lower_bound(x_data.begin(), x_data.end(), x_min_lim));
+  const auto padded_start =
+      std::max(0L, static_cast<long>(raw_start - PADDING_POINTS));
+  const auto start_idx = static_cast<size_t>(padded_start);
+
+  // Find end index, ensuring we don't overflow
+  const auto raw_end =
+      std::distance(x_data.begin(),
+                    std::upper_bound(x_data.begin(), x_data.end(), x_max_lim));
+  const auto max_size = static_cast<long>(x_data.size() - 1);
+  const auto padded_end =
+      std::min(max_size, static_cast<long>(raw_end + PADDING_POINTS));
+  const auto end_idx = static_cast<size_t>(padded_end);
+
+  return XRangeIndices<ValueType>{start_idx, end_idx};
+}
+
+template <class ValueType>
+bool shouldAddPoint(const ValueType current_value, const ValueType last_value,
+                    const ValueType min_distance,
+                    const ValueType prev_difference,
+                    const ValueType current_difference) {
+  // Add point if direction changes or distance exceeds threshold
+  const bool direction_changed =
+      (std::signbit(prev_difference) != std::signbit(current_difference));
+  const bool exceeds_distance =
+      (std::abs(last_value - current_value) > min_distance);
+  return direction_changed || exceeds_distance;
+}
+
+template <class FloatType>
+struct PixelColumnData {
+  std::vector<size_t> indices;
+  FloatType min_val;
+  FloatType max_val;
+  size_t min_idx;
+  size_t max_idx;
+};
+
+template <class FloatType>
+void processPixelColumn(const std::vector<FloatType>& y_data, size_t start_idx,
+                        size_t end_idx, fast_vector<std::size_t>& xy_indices) {
+  if (end_idx - start_idx <= MAX_POINTS_PER_PIXEL) {
+    // For small segments, include all points
+    for (auto i = start_idx; i < end_idx; ++i) {
+      xy_indices.push_back(i);
+    }
+    return;
+  }
+
+  // Find min/max points in this column
+  auto [min_idx, max_idx, min_val, max_val] =
+      findMinMaxIndices(y_data, start_idx, end_idx);
+
+  // Always include the start point
+  xy_indices.push_back(start_idx);
+
+  // Add min/max points in order of appearance
+  if (min_idx < max_idx) {
+    xy_indices.push_back_if_not_in_back(min_idx);
+    xy_indices.push_back_if_not_in_back(max_idx);
+  } else {
+    xy_indices.push_back_if_not_in_back(max_idx);
+    xy_indices.push_back_if_not_in_back(min_idx);
+  }
+
+  // Include end point if it's significant
+  if (end_idx - 1 != max_idx && end_idx - 1 != min_idx) {
+    xy_indices.push_back_if_not_in_back(end_idx - 1);
+  }
+}
+}  // namespace
 
 template <class ValueType>
 static auto computeXStartIdx(const ValueType x_min_lim,
@@ -193,7 +195,8 @@ static auto computeXEndIdx(const ValueType x_max_lim,
 template <class ValueType, class IndexType, class ForwardIt>
 static auto calculateXIndicesBetweenStartEnd(
     const ForwardIt start_x_idx, const ForwardIt end_x_idx,
-    const Scaling x_scaling, const Lim<ValueType> x_lim, const juce::Rectangle<int> &axes_bounds,
+    const Scaling x_scaling, const Lim<ValueType> x_lim,
+    const juce::Rectangle<int>& axes_bounds,
     const std::vector<ValueType>& x_data,
     std::vector<IndexType>& x_based_idxs_out) {
   const auto [x_scale, x_offset] =
@@ -214,7 +217,8 @@ static auto calculateXIndicesBetweenStartEnd(
           (std::signbit(last_x_diff) != std::signbit(current_x_diff));
       last_x_diff = current_x_diff;
 
-      if (force_add_x || (std::abs(last_added_x - x_data[i])) > inverse_x_scale) {
+      if (force_add_x ||
+          (std::abs(last_added_x - x_data[i])) > inverse_x_scale) {
         last_added_x = x_data[i];
         x_based_idxs_out[pixel_point_index++] = i;
       }
@@ -236,101 +240,99 @@ static auto calculateXIndicesBetweenStartEnd(
 
 template <class FloatType>
 void Downsampler<FloatType>::calculateXIndices(
-    const Scaling x_scaling, 
-    const Lim<FloatType> x_lim, 
+    const Scaling x_scaling, const Lim<FloatType> x_lim,
     const juce::Rectangle<int>& axes_bounds,
     const std::vector<FloatType>& x_data,
-    std::vector<std::size_t>& x_based_idxs_out) 
-{
-    if (x_data.empty()) {
-        x_based_idxs_out.clear();
-        return;
+    std::vector<std::size_t>& x_based_idxs_out) {
+  if (x_data.empty()) {
+    x_based_idxs_out.clear();
+    return;
+  }
+
+  x_based_idxs_out.resize(x_data.size());
+
+  // Handle small datasets without downsampling
+  if (x_data.size() < MIN_POINTS_FOR_DOWNSAMPLING) {
+    std::iota(x_based_idxs_out.begin(), x_based_idxs_out.end(), 0u);
+    return;
+  }
+
+  // Find visible data range
+  const auto range = findDataRange(x_lim.min, x_lim.max, x_data);
+
+  // Set initial point
+  x_based_idxs_out[0] = range.start_idx;
+
+  // Calculate scale factors
+  const auto [scale, offset] =
+      getXScaleAndOffset(float(axes_bounds.getWidth()), x_lim, x_scaling);
+  const auto inverse_scale = 1.0f / scale;
+
+  size_t output_idx = 1;
+  float last_added_x = x_data[range.start_idx];
+  float last_diff = 0.f;
+
+  // Process points based on scaling type
+  if (x_scaling == Scaling::linear) {
+    for (size_t i = range.start_idx + 1; i < range.end_idx; ++i) {
+      const auto current_diff = i > 0 ? x_data[i - 1] - x_data[i] : 0.f;
+
+      if (shouldAddPoint(x_data[i], last_added_x, inverse_scale, last_diff,
+                         current_diff)) {
+        last_added_x = x_data[i];
+        x_based_idxs_out[output_idx++] = i;
+      }
+
+      last_diff = current_diff;
     }
-
-    x_based_idxs_out.resize(x_data.size());
-
-    // Handle small datasets without downsampling
-    if (x_data.size() < MIN_POINTS_FOR_DOWNSAMPLING) {
-        std::iota(x_based_idxs_out.begin(), x_based_idxs_out.end(), 0u);
-        return;
+  } else if (x_scaling == Scaling::logarithmic) {
+    for (size_t i = range.start_idx + 1; i < range.end_idx; ++i) {
+      if (std::log10(std::abs(x_data[i] / last_added_x)) > inverse_scale) {
+        last_added_x = x_data[i];
+        x_based_idxs_out[output_idx++] = i;
+      }
     }
+  }
 
-    // Find visible data range
-    const auto range = findDataRange(x_lim.min, x_lim.max, x_data);
-    
-    // Set initial point
-    x_based_idxs_out[0] = range.start_idx;
-    
-    // Calculate scale factors
-    const auto [scale, offset] = getXScaleAndOffset(
-        float(axes_bounds.getWidth()), x_lim, x_scaling);
-    const auto inverse_scale = 1.0f / scale;
-
-    size_t output_idx = 1;
-    float last_added_x = x_data[range.start_idx];
-    float last_diff = 0.f;
-
-    // Process points based on scaling type
-    if (x_scaling == Scaling::linear) {
-        for (size_t i = range.start_idx + 1; i < range.end_idx; ++i) {
-            const auto current_diff = i > 0 ? x_data[i - 1] - x_data[i] : 0.f;
-            
-            if (shouldAddPoint(x_data[i], last_added_x, inverse_scale, 
-                             last_diff, current_diff)) {
-                last_added_x = x_data[i];
-                x_based_idxs_out[output_idx++] = i;
-            }
-            
-            last_diff = current_diff;
-        }
-    } else if (x_scaling == Scaling::logarithmic) {
-        for (size_t i = range.start_idx + 1; i < range.end_idx; ++i) {
-            if (std::log10(std::abs(x_data[i] / last_added_x)) > inverse_scale) {
-                last_added_x = x_data[i];
-                x_based_idxs_out[output_idx++] = i;
-            }
-        }
-    }
-
-    // Add final point and resize
-    x_based_idxs_out[output_idx++] = range.end_idx;
-    x_based_idxs_out.resize(output_idx);
+  // Add final point and resize
+  x_based_idxs_out[output_idx++] = range.end_idx;
+  x_based_idxs_out.resize(output_idx);
 }
 
 template <class FloatType>
 void Downsampler<FloatType>::calculateXYBasedIdxs(
     const std::vector<std::size_t>& x_indices,
     const std::vector<FloatType>& y_data,
-    std::vector<std::size_t>& xy_indices_out) 
-{
-    if (x_indices.empty()) {
-        xy_indices_out.clear();
-        return;
-    }
+    std::vector<std::size_t>& xy_indices_out) {
+  if (x_indices.empty()) {
+    xy_indices_out.clear();
+    return;
+  }
 
-    fast_vector<std::size_t> xy_indices(xy_indices_out, y_data.size());
+  fast_vector<std::size_t> xy_indices(xy_indices_out, y_data.size());
 
-    if (y_data.size() < MIN_POINTS_FOR_DOWNSAMPLING) {
-        xy_indices = x_indices;
-        xy_indices_out = xy_indices.get();
-        return;
-    }
-
-    // Process each segment between x-indices
-    for (auto i_it = x_indices.begin(); std::next(i_it) != x_indices.end(); ++i_it) {
-        const auto start_idx = *i_it;
-        const auto end_idx = *std::next(i_it);
-
-        processPixelColumn(y_data, start_idx, end_idx, xy_indices);
-    }
-
-    // Ensure the last point is included
-    if (!x_indices.empty()) {
-        xy_indices.push_back_if_not_in_back(x_indices.back());
-    }
-
-    // Transfer results back to output vector
+  if (y_data.size() < MIN_POINTS_FOR_DOWNSAMPLING) {
+    xy_indices = x_indices;
     xy_indices_out = xy_indices.get();
+    return;
+  }
+
+  // Process each segment between x-indices
+  for (auto i_it = x_indices.begin(); std::next(i_it) != x_indices.end();
+       ++i_it) {
+    const auto start_idx = *i_it;
+    const auto end_idx = *std::next(i_it);
+
+    processPixelColumn(y_data, start_idx, end_idx, xy_indices);
+  }
+
+  // Ensure the last point is included
+  if (!x_indices.empty()) {
+    xy_indices.push_back_if_not_in_back(x_indices.back());
+  }
+
+  // Transfer results back to output vector
+  xy_indices_out = xy_indices.get();
 }
 
 template class Downsampler<float>;

--- a/source/cmp_frame.cpp
+++ b/source/cmp_frame.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/source/cmp_grid.cpp
+++ b/source/cmp_grid.cpp
@@ -11,8 +11,8 @@
 #include <tuple>
 
 #include "cmp_datamodels.h"
-#include "cmp_series.h"
 #include "cmp_plot.h"
+#include "cmp_series.h"
 #include "cmp_utils.h"
 
 namespace cmp {
@@ -120,8 +120,7 @@ void Grid::addGridLines(const std::vector<float> &ticks,
 
     const auto getScaleOffset = [&]() {
       if (direction == GridLine::Direction::vertical) {
-        return getXScaleAndOffset(axes_bounds.getWidth(), m_x_lim,
-                                  m_x_scaling);
+        return getXScaleAndOffset(axes_bounds.getWidth(), m_x_lim, m_x_scaling);
       }
       return getYScaleAndOffset(axes_bounds.getHeight(), m_y_lim, m_y_scaling);
     };

--- a/source/cmp_legend.cpp
+++ b/source/cmp_legend.cpp
@@ -8,8 +8,8 @@
 #include "cmp_legend.h"
 
 #include "cmp_datamodels.h"
-#include "cmp_series.h"
 #include "cmp_plot.h"
+#include "cmp_series.h"
 
 void cmp::Legend::setLegend(const StringVector &series_descriptions) {
   m_label_texts = series_descriptions;

--- a/source/cmp_lookandfeel.cpp
+++ b/source/cmp_lookandfeel.cpp
@@ -14,9 +14,9 @@
 
 #include "cmp_axis_transform.h"
 #include "cmp_datamodels.h"
-#include "cmp_series.h"
 #include "cmp_grid.h"
 #include "cmp_label.h"
+#include "cmp_series.h"
 #include "cmp_utils.h"
 #include "juce_core/system/juce_PlatformDefs.h"
 
@@ -204,7 +204,8 @@ juce::Font PlotLookAndFeel::getButtonFont() const noexcept {
   return juce::Font(14.0f, juce::Font::plain);
 }
 
-int PlotLookAndFeel::getColourFromSeriesID(const std::size_t series_index) const {
+int PlotLookAndFeel::getColourFromSeriesID(
+    const std::size_t series_index) const {
   /**< Colour vector which is useful when iterating over the six series
    * colours.*/
   static const std::vector<int> SeriesColours{
@@ -278,11 +279,11 @@ juce::Point<int> PlotLookAndFeel::getTracePointPositionFrom(
     const juce::Rectangle<int>& axes_bounds, const Lim<float> x_lim,
     const Scaling x_scaling, const Lim<float> y_lim, const Scaling y_scaling,
     const juce::Point<float> series_values) const noexcept {
-  const auto [x_scale, x_offset] = getXScaleAndOffset(
-      float(axes_bounds.getWidth()), x_lim, x_scaling);
+  const auto [x_scale, x_offset] =
+      getXScaleAndOffset(float(axes_bounds.getWidth()), x_lim, x_scaling);
 
-  const auto [y_scale, y_offset] = getYScaleAndOffset(
-      float(axes_bounds.getHeight()), y_lim, y_scaling);
+  const auto [y_scale, y_offset] =
+      getYScaleAndOffset(float(axes_bounds.getHeight()), y_lim, y_scaling);
 
   float x;
   float y;
@@ -301,9 +302,9 @@ juce::Point<int> PlotLookAndFeel::getTracePointPositionFrom(
   return juce::Point<float>(x, y).toInt();
 }
 
-void PlotLookAndFeel::drawSeries(
-    juce::Graphics& g, const SeriesDataView series_data,
-    const juce::Rectangle<int>& series_bounds) {
+void PlotLookAndFeel::drawSeries(juce::Graphics& g,
+                                 const SeriesDataView series_data,
+                                 const juce::Rectangle<int>& series_bounds) {
   juce::Path series_path;
   const juce::PathStrokeType stroke_type =
       series_data.series_attribute.path_stroke_type
@@ -375,10 +376,9 @@ void PlotLookAndFeel::drawSeries(
           gradient_colours.first, 0.f, gradient_colours.second,
           series_bounds_f.getHeight());
 
-      series_path.lineTo(pixel_points.back().getX(),
-                        series_bounds.getBottom());
+      series_path.lineTo(pixel_points.back().getX(), series_bounds.getBottom());
       series_path.lineTo(pixel_points.front().getX(),
-                        series_bounds.getBottom());
+                         series_bounds.getBottom());
       series_path.closeSubPath();
       g.setGradientFill(gradient);
       g.fillPath(series_path);
@@ -495,8 +495,7 @@ void PlotLookAndFeel::drawLegendBackground(
   g.fillRect(legend_bound);
 }
 
-void PlotLookAndFeel::drawSpread(juce::Graphics& g,
-                                 const Series* first_series,
+void PlotLookAndFeel::drawSpread(juce::Graphics& g, const Series* first_series,
                                  const Series* second_series,
                                  const juce::Colour& spread_colour) {
   juce::Path path;
@@ -615,15 +614,15 @@ void PlotLookAndFeel::drawSelectionArea(
 
 void PlotLookAndFeel::updateXPixelPoints(
     const std::vector<std::size_t>& update_only_these_indices,
-    const Scaling x_scaling, const Lim<float> x_lim, const juce::Rectangle<int> &axes_bounds,
-    const std::vector<float>& x_data,
+    const Scaling x_scaling, const Lim<float> x_lim,
+    const juce::Rectangle<int>& axes_bounds, const std::vector<float>& x_data,
     std::vector<std::size_t>& pixel_points_indices,
     PixelPoints& pixel_points) noexcept {
   // Pixel points are axes-area-local: x_lim.min maps to pixel 0 and
   // x_lim.max to the series-area width. The caller owns the sizing of
   // 'pixel_points'; this method only writes coordinates.
-  const auto transform = AxisTransform({x_lim, x_scaling}, 0.0f,
-                                       axes_bounds.toFloat().getWidth());
+  const auto transform =
+      AxisTransform({x_lim, x_scaling}, 0.0f, axes_bounds.toFloat().getWidth());
 
   if (!update_only_these_indices.empty()) {
     if (pixel_points_indices.size() != x_data.size()) {
@@ -646,16 +645,16 @@ void PlotLookAndFeel::updateXPixelPoints(
 
 void PlotLookAndFeel::updateYPixelPoints(
     const std::vector<std::size_t>& update_only_these_indices,
-    const Scaling y_scaling, const Lim<float> y_lim, const juce::Rectangle<int> &axes_bounds,
-    const std::vector<float>& y_data,
+    const Scaling y_scaling, const Lim<float> y_lim,
+    const juce::Rectangle<int>& axes_bounds, const std::vector<float>& y_data,
     const std::vector<std::size_t>& pixel_points_indices,
     PixelPoints& pixel_points) noexcept {
   // Pixel points are axes-area-local and the y-axis is inverted: y_lim.min
   // maps to the series-area height (bottom) and y_lim.max to pixel 0 (top).
   // The caller owns the sizing of 'pixel_points'; this method only writes
   // coordinates.
-  const auto transform = AxisTransform(
-      {y_lim, y_scaling}, axes_bounds.toFloat().getHeight(), 0.0f);
+  const auto transform = AxisTransform({y_lim, y_scaling},
+                                       axes_bounds.toFloat().getHeight(), 0.0f);
 
   if (!update_only_these_indices.empty()) {
     if (pixel_points_indices.size() != y_data.size()) {
@@ -679,10 +678,9 @@ void PlotLookAndFeel::updateYPixelPoints(
 }
 
 void PlotLookAndFeel::updateVerticalGridLineTicksAuto(
-    const juce::Rectangle<int>& bounds,
-    const Lim_f& x_lim,
-    const Scaling x_scaling,
-    const GridType grid_type, const std::vector<float>& previous_ticks,
+    const juce::Rectangle<int>& bounds, const Lim_f& x_lim,
+    const Scaling x_scaling, const GridType grid_type,
+    const std::vector<float>& previous_ticks,
     std::vector<float>& x_ticks) noexcept {
   x_ticks.clear();
 
@@ -715,8 +713,7 @@ void PlotLookAndFeel::updateVerticalGridLineTicksAuto(
     num_ticks_per_power = std::size_t(tiny_grids ? num_ticks_per_power * 1.5
                                                  : num_ticks_per_power);
 
-    x_ticks = getLogarithmicTicks(
-        num_ticks_per_power, x_lim, previous_ticks);
+    x_ticks = getLogarithmicTicks(num_ticks_per_power, x_lim, previous_ticks);
   };
 
   if (x_scaling == Scaling::linear) {
@@ -727,10 +724,9 @@ void PlotLookAndFeel::updateVerticalGridLineTicksAuto(
 }
 
 void PlotLookAndFeel::updateHorizontalGridLineTicksAuto(
-    const juce::Rectangle<int>& bounds,
-    const Lim_f& y_lim,
-    const Scaling y_scaling,
-    const GridType grid_type, const std::vector<float>& previous_ticks,
+    const juce::Rectangle<int>& bounds, const Lim_f& y_lim,
+    const Scaling y_scaling, const GridType grid_type,
+    const std::vector<float>& previous_ticks,
     std::vector<float>& y_ticks) noexcept {
   y_ticks.clear();
 
@@ -747,7 +743,7 @@ void PlotLookAndFeel::updateHorizontalGridLineTicksAuto(
     }
     num_horizontal_lines = tiny_grids ? std::size_t(num_horizontal_lines * 1.5)
                                       : num_horizontal_lines;
-    
+
     y_ticks = TicksGenerator::generateTicks(
         y_lim.min, y_lim.max, num_horizontal_lines, previous_ticks);
   };
@@ -762,8 +758,7 @@ void PlotLookAndFeel::updateHorizontalGridLineTicksAuto(
     num_ticks_per_power = tiny_grids ? std::size_t(num_ticks_per_power * 1.5)
                                      : num_ticks_per_power;
 
-    y_ticks = getLogarithmicTicks(
-        num_ticks_per_power, y_lim, previous_ticks);
+    y_ticks = getLogarithmicTicks(num_ticks_per_power, y_lim, previous_ticks);
   };
 
   if (y_scaling == Scaling::linear) {
@@ -927,10 +922,10 @@ void PlotLookAndFeel::updateGridLabels(const juce::Rectangle<int>& axes_bounds,
             getLabelWidthAndHeight(font, label);
 
         const auto is_x_axis_label_below_axes = isXAxisLabelsBelowAxesArea();
-        const auto bound_y = is_x_axis_label_below_axes
-                                 ? axes_bounds.getBottom() +
-                                       getXGridLabelDistanceFromAxesBound()
-                                 : axes_bounds.getTopLeft().y - label_height;
+        const auto bound_y =
+            is_x_axis_label_below_axes
+                ? axes_bounds.getBottom() + getXGridLabelDistanceFromAxesBound()
+                : axes_bounds.getTopLeft().y - label_height;
 
         const auto bound =
             juce::Rectangle<int>(int(position.x) - label_width / 2, bound_y,
@@ -962,9 +957,8 @@ void PlotLookAndFeel::updateGridLabels(const juce::Rectangle<int>& axes_bounds,
 }
 
 void PlotLookAndFeel::updateXYTitleLabels(
-    const juce::Rectangle<int>& bounds,
-    const juce::Rectangle<int>& axes_bounds, juce::Label& x_label,
-    juce::Label& y_label, juce::Label& title_label) {
+    const juce::Rectangle<int>& bounds, const juce::Rectangle<int>& axes_bounds,
+    juce::Label& x_label, juce::Label& y_label, juce::Label& title_label) {
   const auto font = getXYTitleFont();
 
   const auto x_margin = int(getMargin());
@@ -1001,8 +995,7 @@ void PlotLookAndFeel::updateXYTitleLabels(
       float(y_area.getY())));
 
   const auto y_mid_point_bottom =
-      (bounds.getHeight() - (axes_bounds.getY() + axes_bounds.getHeight())) /
-      2;
+      (bounds.getHeight() - (axes_bounds.getY() + axes_bounds.getHeight())) / 2;
 
   y_label.setBounds(y_area);
 
@@ -1023,6 +1016,8 @@ void PlotLookAndFeel::updateXYTitleLabels(
       bound_y, title_width, font_height);
 }
 
-bool PlotLookAndFeel::isXAxisLabelsBelowAxesArea() const noexcept { return true; }
+bool PlotLookAndFeel::isXAxisLabelsBelowAxesArea() const noexcept {
+  return true;
+}
 
 }  // namespace cmp

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -14,12 +14,12 @@
 
 #include "cmp_datamodels.h"
 #include "cmp_frame.h"
-#include "cmp_selection_area.h"
-#include "cmp_series.h"
 #include "cmp_grid.h"
 #include "cmp_label.h"
 #include "cmp_legend.h"
 #include "cmp_lookandfeel.h"
+#include "cmp_selection_area.h"
+#include "cmp_series.h"
 #include "cmp_trace.h"
 #include "cmp_utils.h"
 #include "juce_core/system/juce_PlatformDefs.h"
@@ -65,11 +65,10 @@ std::tuple<size_t, const Series*> Plot::findNearestPoint(
   size_t data_point_index{0};
   size_t closest_data_point_index{0};
 
-  const auto series_exsists =
-      std::find_if(m_series->begin(), m_series->end(),
-                   [&series](const auto& s) {
-                     return s.get() == series;
-                   }) != m_series->end();
+  const auto series_exsists = std::find_if(m_series->begin(), m_series->end(),
+                                           [&series](const auto& s) {
+                                             return s.get() == series;
+                                           }) != m_series->end();
 
   const Series* nearest_series{series_exsists ? series : nullptr};
 
@@ -166,9 +165,9 @@ Plot::Plot(const Scaling x_scaling, const Scaling y_scaling)
   };
 
   m_legend->onNumberOfDescriptionsChanged = [this](const auto& desc) {
-      const auto *lnf = getPlotLookAndFeel();
-      const auto legend_bounds = lnf->getLegendBounds(m_axes_bounds, desc);
-      m_legend->setBounds(legend_bounds);
+    const auto* lnf = getPlotLookAndFeel();
+    const auto legend_bounds = lnf->getLegendBounds(m_axes_bounds, desc);
+    m_legend->setBounds(legend_bounds);
   };
 
   m_trace->onTracePointChanged = [this](const auto* trace_point,
@@ -369,9 +368,8 @@ void Plot::plotUpdateYOnly(const std::vector<std::vector<float>>& y_data) {
   repaint(m_axes_bounds);
 }
 
-void Plot::fillBetween(
-    const std::vector<SpreadIndex>& spread_indices,
-    const std::vector<juce::Colour>& fill_area_colours) {
+void Plot::fillBetween(const std::vector<SpreadIndex>& spread_indices,
+                       const std::vector<juce::Colour>& fill_area_colours) {
   m_spread_list.resize(spread_indices.size());
   auto spread_it = m_spread_list.begin();
 
@@ -391,8 +389,7 @@ void Plot::fillBetween(
 
     auto& spread = *spread_it++;
     if (!spread) {
-      spread =
-          std::make_unique<Spread>(first_series, second_series, colour);
+      spread = std::make_unique<Spread>(first_series, second_series, colour);
       spread->setBounds(m_axes_bounds);
       spread->setLookAndFeel(getPlotLookAndFeel());
       addAndMakeVisible(spread.get());
@@ -438,7 +435,8 @@ static auto jassetLogLimBelowZero(const cmp::Scaling scaling,
 
 void Plot::setScaling(const Scaling x_scaling,
                       const Scaling y_scaling) noexcept {
-  if (x_scaling != m_x_scaling.getValue() || y_scaling != m_y_scaling.getValue()) {
+  if (x_scaling != m_x_scaling.getValue() ||
+      y_scaling != m_y_scaling.getValue()) {
     jassetLogLimBelowZero(x_scaling, m_x_lim_start);
     jassetLogLimBelowZero(y_scaling, m_y_lim_start);
 
@@ -504,7 +502,7 @@ void Plot::setGridType(const GridType grid_type) {
 void Plot::clearTracePoints() noexcept { m_trace->clear(); }
 
 void Plot::resizeChildrens() {
-  const auto *lnf = getPlotLookAndFeel();
+  const auto* lnf = getPlotLookAndFeel();
   const auto plot_bound = lnf->getPlotBounds(getBounds());
   const auto axes_bound = lnf->getAxesBounds(getBounds(), this);
 
@@ -543,7 +541,7 @@ void Plot::resizeChildrens() {
 void Plot::resized() { resizeChildrens(); }
 
 void Plot::paint(juce::Graphics& g) {
-  auto *lnf = getPlotLookAndFeel();
+  auto* lnf = getPlotLookAndFeel();
   lnf->drawBackground(g, m_axes_bounds);
 }
 
@@ -572,8 +570,8 @@ void Plot::lookAndFeelChanged() {
 
 template <SeriesType t_series_type>
 void Plot::addSeriesInternal(std::unique_ptr<Series>& series,
-                                const size_t series_index) {
-  auto *lnf = getPlotLookAndFeel();
+                             const size_t series_index) {
+  auto* lnf = getPlotLookAndFeel();
   series = std::make_unique<Series>();
 
   m_axes_bounds.addObserver(*series);
@@ -597,9 +595,8 @@ void Plot::addSeriesInternal(std::unique_ptr<Series>& series,
 }
 
 template <SeriesType t_series_type>
-void Plot::updateSeriesYData(
-    const std::vector<std::vector<float>>& y_data,
-    const SeriesAttributeList& series_attribute_list) {
+void Plot::updateSeriesYData(const std::vector<std::vector<float>>& y_data,
+                             const SeriesAttributeList& series_attribute_list) {
   if (y_data.empty()) return;
 
   UNLIKELY if (y_data.size() != m_series->size<t_series_type>()) {
@@ -798,8 +795,7 @@ void Plot::moveSelectedTracePoints(const juce::MouseEvent& event) {
   std::map<Series*, std::vector<size_t>> series_data_point_map;
   for (const auto& trace_label_point : m_trace->getTraceLabelPoints()) {
     if (!trace_label_point.isSelected()) continue;
-    const auto target_series =
-        trace_label_point.trace_point->associated_series;
+    const auto target_series = trace_label_point.trace_point->associated_series;
     const auto data_point_index =
         trace_label_point.trace_point->data_point_index;
 
@@ -913,7 +909,7 @@ void Plot::mouseDown(const juce::MouseEvent& event) {
   if (isVisible()) {
     m_prev_mouse_position = getMousePositionRelativeToAxesArea(event);
 
-    const auto *lnf = getPlotLookAndFeel();
+    const auto* lnf = getPlotLookAndFeel();
     if (m_selected_area.get() == event.eventComponent) {
       if (event.mods.isRightButtonDown()) {
         mouseHandler(
@@ -944,7 +940,7 @@ void Plot::mouseDown(const juce::MouseEvent& event) {
 
 void Plot::mouseDrag(const juce::MouseEvent& event) {
   if (isVisible()) {
-    const auto *lnf = getPlotLookAndFeel();
+    const auto* lnf = getPlotLookAndFeel();
     if (m_legend.get() == event.eventComponent) {
       mouseHandler(event,
                    lnf->getUserInputAction(UserInput::left | UserInput::drag |
@@ -982,7 +978,7 @@ void Plot::mouseDrag(const juce::MouseEvent& event) {
 
 void Plot::mouseUp(const juce::MouseEvent& event) {
   if (isVisible()) {
-    const auto *lnf = getPlotLookAndFeel();
+    const auto* lnf = getPlotLookAndFeel();
     if (m_selected_area.get() == event.eventComponent &&
         m_mouse_drag_state == MouseDragState::drag) {
       if (!event.mods.isRightButtonDown()) {

--- a/source/cmp_plot3d.cpp
+++ b/source/cmp_plot3d.cpp
@@ -12,11 +12,11 @@
 
 #include "cmp_axes3dbox.h"
 #include "cmp_camera3d.h"
-#include "cmp_series3d.h"
 #include "cmp_lookandfeel.h"
 #include "cmp_math3d.h"
 #include "cmp_plot.h"
 #include "cmp_projector3d.h"
+#include "cmp_series3d.h"
 
 namespace cmp {
 
@@ -224,8 +224,7 @@ juce::Rectangle<int> Plot3D::getAxesBounds3D() noexcept {
       static_cast<int>(2.0f * lnf->getGridLabelFont().getHeight());
   const auto axis_label_space =
       static_cast<int>(lnf->getXYTitleFont().getHeight());
-  const auto label_space =
-      2 * margin + tick_label_space + axis_label_space;
+  const auto label_space = 2 * margin + tick_label_space + axis_label_space;
 
   return getLocalBounds().reduced(label_space);
 }

--- a/source/cmp_selection_area.cpp
+++ b/source/cmp_selection_area.cpp
@@ -19,7 +19,8 @@ void SelectionArea::setStartPosition(
   m_is_start_pos_set = true;
 }
 
-void SelectionArea::setEndPosition(const juce::Point<int>& end_position) noexcept {
+void SelectionArea::setEndPosition(
+    const juce::Point<int>& end_position) noexcept {
   m_end_pos = end_position;
 }
 
@@ -31,7 +32,9 @@ juce::Point<int> SelectionArea::getEndPosition() const noexcept {
   return m_end_pos;
 }
 
-bool SelectionArea::isStartPosSet() const noexcept { return m_is_start_pos_set; }
+bool SelectionArea::isStartPosSet() const noexcept {
+  return m_is_start_pos_set;
+}
 
 void SelectionArea::reset() noexcept {
   m_start_pos = {0, 0};
@@ -39,8 +42,8 @@ void SelectionArea::reset() noexcept {
   m_is_start_pos_set = false;
 }
 
-void SelectionArea::observableValueUpdated(ObserverId id, const Lim<float> &new_value)
-{
+void SelectionArea::observableValueUpdated(ObserverId id,
+                                           const Lim<float>& new_value) {
   if (id == ObserverId::XLim) {
     m_x_lim = new_value;
   } else if (id == ObserverId::YLim) {
@@ -48,7 +51,8 @@ void SelectionArea::observableValueUpdated(ObserverId id, const Lim<float> &new_
   }
 }
 
-void SelectionArea::observableValueUpdated(ObserverId id, const Scaling &new_value) {
+void SelectionArea::observableValueUpdated(ObserverId id,
+                                           const Scaling& new_value) {
   if (id == ObserverId::XScaling) {
     m_x_scaling = new_value;
   } else if (id == ObserverId::YScaling) {
@@ -84,15 +88,12 @@ juce::Rectangle<ValueType> SelectionArea::getDataBound() const noexcept {
   const auto x_start = getXDataFromXPixelCoordinate(
       float(start_pos.getX()), local_axes_bounds, m_x_lim, m_x_scaling);
   const auto x_end = getXDataFromXPixelCoordinate(
-      float(end_pos.getX()), local_axes_bounds, m_x_lim,
-      m_x_scaling);
+      float(end_pos.getX()), local_axes_bounds, m_x_lim, m_x_scaling);
 
   const auto y_start = getYDataFromYPixelCoordinate(
-      float(start_pos.getY()), local_axes_bounds, m_y_lim,
-      m_y_scaling);
+      float(start_pos.getY()), local_axes_bounds, m_y_lim, m_y_scaling);
   const auto y_end = getYDataFromYPixelCoordinate(
-      float(end_pos.getY()), local_axes_bounds, m_y_lim,
-      m_y_scaling);
+      float(end_pos.getY()), local_axes_bounds, m_y_lim, m_y_scaling);
 
   const auto x_min = std::min(x_start, x_end);
   const auto x_width = std::max(x_start, x_end) - x_min;
@@ -105,7 +106,8 @@ juce::Rectangle<ValueType> SelectionArea::getDataBound() const noexcept {
 template juce::Rectangle<float> SelectionArea::getDataBound() const noexcept;
 
 template <typename ValueType>
-juce::Rectangle<ValueType> SelectionArea::getSelectedAreaBound() const noexcept {
+juce::Rectangle<ValueType> SelectionArea::getSelectedAreaBound()
+    const noexcept {
   const auto start_pos = this->getStartPosition();
   const auto end_pos = this->getEndPosition();
 
@@ -117,6 +119,7 @@ juce::Rectangle<ValueType> SelectionArea::getSelectedAreaBound() const noexcept 
   return juce::Rectangle<ValueType>{x_min, y_min, x_width, y_height};
 };
 
-template juce::Rectangle<int> SelectionArea::getSelectedAreaBound() const noexcept;
+template juce::Rectangle<int> SelectionArea::getSelectedAreaBound()
+    const noexcept;
 
 }  // namespace cmp

--- a/source/cmp_series.cpp
+++ b/source/cmp_series.cpp
@@ -40,7 +40,7 @@ const SeriesAttribute& Series::getSeriesAttribute() const noexcept {
   return m_series_attributes;
 }
 
-void Series::setIndicesToUpdate(const std::vector<std::size_t> indices){
+void Series::setIndicesToUpdate(const std::vector<std::size_t> indices) {
   m_indices_to_update = indices;
   updateXY();
   m_indices_to_update.clear();
@@ -52,7 +52,7 @@ void Series::setColour(const juce::Colour series_colour) {
 
 std::tuple<juce::Point<float>, juce::Point<float>, size_t>
 Series::findClosestPixelPointTo(const juce::Point<float>& this_pixel_point,
-                                   bool check_only_distance_from_x) const {
+                                bool check_only_distance_from_x) const {
   // No pixel points.
   jassert(!m_pixel_points.empty());
 
@@ -71,15 +71,13 @@ Series::findClosestPixelPointTo(const juce::Point<float>& this_pixel_point,
       closest_distance = current_distance;
       closest_pixel_point = pixel_point;
       closest_i = i;
-      closest_data_point =
-          juce::Point<float>(m_x_data[m_xy_indices[i]],
-                             m_y_data[m_xy_indices[i]]);
+      closest_data_point = juce::Point<float>(m_x_data[m_xy_indices[i]],
+                                              m_y_data[m_xy_indices[i]]);
     }
     i++;
   }
 
-  return {closest_pixel_point, closest_data_point,
-          m_xy_indices[closest_i]};
+  return {closest_pixel_point, closest_data_point, m_xy_indices[closest_i]};
 }
 
 std::pair<juce::Point<float>, size_t> Series::findClosestDataPointTo(
@@ -137,12 +135,11 @@ juce::Point<float> Series::getDataPointFromDataPointIndex(
                             m_y_data[data_point_index]);
 };
 
-void Series::observableValueUpdated(ObserverId id, const bool &new_value)
-{
+void Series::observableValueUpdated(ObserverId id, const bool& new_value) {
   updateXY();
 }
 
-void Series::resized() {};
+void Series::resized(){};
 
 void Series::paint(juce::Graphics& g) {
   const SeriesDataView series_data(*this);
@@ -209,20 +206,16 @@ bool Series::setXYValue(const juce::Point<float>& xy_value, size_t index) {
 }
 
 void Series::movePixelPoint(const juce::Point<float>& d_pixel_point,
-                               size_t pixel_point_index) {
+                            size_t pixel_point_index) {
   if (pixel_point_index >= m_x_data.size()) return;
 
   m_x_data[pixel_point_index] += d_pixel_point.getX();
   m_y_data[pixel_point_index] += d_pixel_point.getY();
 }
 
-const std::vector<float>& Series::getYData() const noexcept {
-  return m_y_data;
-}
+const std::vector<float>& Series::getYData() const noexcept { return m_y_data; }
 
-const std::vector<float>& Series::getXData() const noexcept {
-  return m_x_data;
-}
+const std::vector<float>& Series::getXData() const noexcept { return m_x_data; }
 
 const PixelPoints& Series::getPixelPoints() const noexcept {
   return m_pixel_points;
@@ -234,7 +227,7 @@ const std::vector<size_t>& Series::getPixelPointIndices() const noexcept {
 
 void Series::updateX() {
   // x_lim must be set to calculate the xdata.
-  if(!m_x_lim || m_x_data.empty()) return;
+  if (!m_x_lim || m_x_data.empty()) return;
 
   updateXIndicesAndPixelPointsIntern(m_indices_to_update);
 }
@@ -257,14 +250,14 @@ void Series::updateXIndicesAndPixelPointsIntern(
       break;
 
     case DownsamplingType::x_downsampling:
-      Downsampler<float>::calculateXIndices(m_x_scaling, m_x_lim, m_axes_bounds, m_x_data,
-                                                m_x_based_ds_indices);
+      Downsampler<float>::calculateXIndices(m_x_scaling, m_x_lim, m_axes_bounds,
+                                            m_x_data, m_x_based_ds_indices);
 
       break;
 
     case DownsamplingType::xy_downsampling:
-      Downsampler<float>::calculateXIndices(m_x_scaling, m_x_lim, m_axes_bounds, m_x_data,
-                                                m_x_based_ds_indices);
+      Downsampler<float>::calculateXIndices(m_x_scaling, m_x_lim, m_axes_bounds,
+                                            m_x_data, m_x_based_ds_indices);
       return;
       break;
 
@@ -274,8 +267,9 @@ void Series::updateXIndicesAndPixelPointsIntern(
 
   auto lnf = static_cast<Plot::LookAndFeelMethods*>(m_lookandfeel);
   m_pixel_points.resize(m_x_based_ds_indices.size());
-  lnf->updateXPixelPoints(update_only_these_indices, m_x_scaling, m_x_lim, m_axes_bounds,
-                          m_x_data, m_x_based_ds_indices, m_pixel_points);
+  lnf->updateXPixelPoints(update_only_these_indices, m_x_scaling, m_x_lim,
+                          m_axes_bounds, m_x_data, m_x_based_ds_indices,
+                          m_pixel_points);
 }
 
 void Series::updateYIndicesAndPixelPointsIntern(
@@ -297,8 +291,9 @@ void Series::updateYIndicesAndPixelPointsIntern(
                                                m_xy_indices);
 
       m_pixel_points.resize(m_xy_indices.size());
-      lnf->updateXPixelPoints(update_only_these_indices, m_x_scaling, m_x_lim, m_axes_bounds,
-                              m_x_data, m_xy_indices, m_pixel_points);
+      lnf->updateXPixelPoints(update_only_these_indices, m_x_scaling, m_x_lim,
+                              m_axes_bounds, m_x_data, m_xy_indices,
+                              m_pixel_points);
       break;
 
     default:
@@ -306,8 +301,9 @@ void Series::updateYIndicesAndPixelPointsIntern(
   }
 
   m_pixel_points.resize(m_xy_indices.size());
-  lnf->updateYPixelPoints(update_only_these_indices, m_y_scaling, m_y_lim, m_axes_bounds,
-                          m_y_data, m_xy_indices, m_pixel_points);
+  lnf->updateYPixelPoints(update_only_these_indices, m_y_scaling, m_y_lim,
+                          m_axes_bounds, m_y_data, m_xy_indices,
+                          m_pixel_points);
 }
 
 void Series::updateXY() {
@@ -319,24 +315,20 @@ void Series::setType(const SeriesType series_type) {
   m_series_type = series_type;
 }
 
-SeriesType Series::getType() const noexcept {
-  return m_series_type;
-}
+SeriesType Series::getType() const noexcept { return m_series_type; }
 
-void Series::observableValueUpdated(ObserverId id, const Scaling &new_value)
-{
+void Series::observableValueUpdated(ObserverId id, const Scaling& new_value) {
   if (id == ObserverId::XScaling) {
     m_x_scaling = new_value;
     updateX();
-  }
-  else if (id == ObserverId::YScaling) {
+  } else if (id == ObserverId::YScaling) {
     m_y_scaling = new_value;
     updateY();
   }
 }
 
-void Series::observableValueUpdated(ObserverId id, const Lim<float> &new_value)
-{
+void Series::observableValueUpdated(ObserverId id,
+                                    const Lim<float>& new_value) {
   if (id == ObserverId::XLim) {
     m_x_lim = new_value;
     if (m_series_type == SeriesType::horizontal) {
@@ -345,8 +337,7 @@ void Series::observableValueUpdated(ObserverId id, const Lim<float> &new_value)
       m_x_data.back() = m_x_lim.max;
     }
     updateXY();
-  }
-  else if (id == ObserverId::YLim) {
+  } else if (id == ObserverId::YLim) {
     m_y_lim = new_value;
     if (m_series_type == SeriesType::vertical) {
       m_y_data.resize(2);
@@ -357,16 +348,16 @@ void Series::observableValueUpdated(ObserverId id, const Lim<float> &new_value)
   }
 }
 
-void Series::observableValueUpdated(ObserverId id, const juce::Rectangle<int> &new_value)
-{
+void Series::observableValueUpdated(ObserverId id,
+                                    const juce::Rectangle<int>& new_value) {
   if (id == ObserverId::AxesBounds) {
     m_axes_bounds = new_value;
     updateXY();
   }
 }
 
-void Series::observableValueUpdated(ObserverId id, const DownsamplingType &new_value)
-{
+void Series::observableValueUpdated(ObserverId id,
+                                    const DownsamplingType& new_value) {
   if (id == ObserverId::DownsamplingType) {
     m_downsampling_type = new_value;
     updateXY();
@@ -378,11 +369,10 @@ void Series::observableValueUpdated(ObserverId id, const DownsamplingType &new_v
 /************************************************************************************/
 
 size_t size_from_series_type(const SeriesList& SeriesList,
-                                 const SeriesType series_type) {
+                             const SeriesType series_type) {
   return std::count_if(SeriesList.begin(), SeriesList.end(),
                        [series_type](const auto& series) {
-                         return series->getType() ==
-                                series_type;
+                         return series->getType() == series_type;
                        });
 }
 
@@ -408,7 +398,7 @@ size_t SeriesList::size<SeriesType::horizontal>() const noexcept {
 }
 
 template <SeriesType t_series_type>
-void SeriesList::resize(size_t new_size_of_type){
+void SeriesList::resize(size_t new_size_of_type) {
   const auto current_size = size<t_series_type>();
 
   if (current_size == new_size_of_type) return;
@@ -423,30 +413,31 @@ void SeriesList::resize(size_t new_size_of_type){
 
     const auto num_to_erase = current_size - new_size_of_type;
     const auto erase_begin = std::find_if(
-        begin(), end(), [](const auto& series) {
-          return series->getType() == t_series_type;
-        });
+        begin(), end(),
+        [](const auto& series) { return series->getType() == t_series_type; });
 
     erase(erase_begin, erase_begin + num_to_erase);
   } else {
-    const auto new_size =  size<SeriesType::any>() - current_size + new_size_of_type;
+    const auto new_size =
+        size<SeriesType::any>() - current_size + new_size_of_type;
     std::vector<std::unique_ptr<Series>>::resize(new_size);
   }
 }
 
 template void SeriesList::resize<SeriesType::normal>(size_t new_size_of_type);
 template void SeriesList::resize<SeriesType::vertical>(size_t new_size_of_type);
-template void SeriesList::resize<SeriesType::horizontal>(size_t new_size_of_type);
+template void SeriesList::resize<SeriesType::horizontal>(
+    size_t new_size_of_type);
 
 template <SeriesType t_series_type>
-std::vector<Series*> SeriesList::getSeriesOfType(){
-    std::vector<Series*> result;
-    for (auto &line : *this) {
-        if (line->getType() == t_series_type) {
-            result.push_back(line.get());
-        }
+std::vector<Series*> SeriesList::getSeriesOfType() {
+  std::vector<Series*> result;
+  for (auto& line : *this) {
+    if (line->getType() == t_series_type) {
+      result.push_back(line.get());
     }
-    return result;
+  }
+  return result;
 }
 
 /************************************************************************************/

--- a/source/cmp_series3d.cpp
+++ b/source/cmp_series3d.cpp
@@ -15,8 +15,8 @@
 namespace cmp {
 
 void Series3D::setValues(const std::vector<float>& x_data,
-                            const std::vector<float>& y_data,
-                            const std::vector<float>& z_data) {
+                         const std::vector<float>& y_data,
+                         const std::vector<float>& z_data) {
   jassert(x_data.size() == y_data.size() && x_data.size() == z_data.size());
 
   m_x_data = x_data;
@@ -106,8 +106,8 @@ void Series3D::resized() { updatePixelPointsIntern(); }
 void Series3D::paint(juce::Graphics& g) {
   if (m_lookandfeel && !m_pixel_points.empty()) {
     const SeriesDataView series_data(m_x_data, m_y_data, m_pixel_points,
-                                            m_pixel_point_indices,
-                                            m_series_attributes);
+                                     m_pixel_point_indices,
+                                     m_series_attributes);
 
     auto* lnf = static_cast<PlotLookAndFeelBase*>(m_lookandfeel);
     lnf->drawSeries(g, series_data, getLocalBounds());

--- a/source/cmp_trace.cpp
+++ b/source/cmp_trace.cpp
@@ -10,8 +10,8 @@
 #include <cstddef>
 
 #include "cmp_datamodels.h"
-#include "cmp_series.h"
 #include "cmp_plot.h"
+#include "cmp_series.h"
 
 namespace cmp {
 
@@ -133,8 +133,7 @@ void Trace::addOrRemoveTracePoint(const Series* series,
                                   const size_t data_point_index,
                                   const TracePointVisibilityType visibility) {
   if (!doesTracePointExist(series, data_point_index)) {
-    addSingleTracePointInternal(series, data_point_index,
-                                        visibility);
+    addSingleTracePointInternal(series, data_point_index, visibility);
   } else {
     removeSingleTracePointAndLabel(series, data_point_index);
   }
@@ -221,22 +220,19 @@ bool Trace::isComponentTraceLabel(const juce::Component* component) const {
              m_trace_labelpoints.end();
 }
 
-void Trace::tracePointCbHelper(const juce::Component *trace_point,
+void Trace::tracePointCbHelper(const juce::Component* trace_point,
                                const juce::Point<float> previous_data_point,
-                               const juce::Point<float> new_data_point)
-{
-    if (onTracePointChanged)
-    {
-        onTracePointChanged(trace_point, previous_data_point, new_data_point);
-    }
+                               const juce::Point<float> new_data_point) {
+  if (onTracePointChanged) {
+    onTracePointChanged(trace_point, previous_data_point, new_data_point);
+  }
 }
 
 void Trace::addSingleTracePointInternal(
     const Series* series, const size_t data_point_index,
     const TracePointVisibilityType trace_point_visibility) {
   auto trace_label = std::make_unique<TraceLabel_f>();
-  auto trace_point =
-      std::make_unique<TracePoint_f>(data_point_index, series);
+  auto trace_point = std::make_unique<TracePoint_f>(data_point_index, series);
 
   if (m_lookandfeel) trace_label->setLookAndFeel(m_lookandfeel);
   if (m_lookandfeel) trace_point->setLookAndFeel(m_lookandfeel);
@@ -263,12 +259,10 @@ bool Trace::doesTracePointExist(const Series* series,
              }) != m_trace_labelpoints.end();
 }
 
-void Trace::addTracePoint(const Series* series,
-                          const size_t data_point_index,
+void Trace::addTracePoint(const Series* series, const size_t data_point_index,
                           const TracePointVisibilityType visibility_type) {
   if (!doesTracePointExist(series, data_point_index)) {
-    addSingleTracePointInternal(series, data_point_index,
-                                        visibility_type);
+    addSingleTracePointInternal(series, data_point_index, visibility_type);
   }
 }
 
@@ -279,8 +273,7 @@ void Trace::selectTracePoint(const juce::Component* component,
   updateSingleTracePoint(&(*it));
 }
 
-void Trace::observableValueUpdated(ObserverId id, const bool &new_value)
-{
+void Trace::observableValueUpdated(ObserverId id, const bool& new_value) {
   updateAllTracePoints();
 }
 
@@ -305,7 +298,7 @@ void Trace::observableValueUpdated(ObserverId id, const Scaling& new_value) {
 }
 
 void Trace::observableValueUpdated(ObserverId id,
-                                    const juce::Rectangle<int>& new_value) {
+                                   const juce::Rectangle<int>& new_value) {
   if (id == ObserverId::AxesBounds) {
     m_axes_bounds = new_value;
     updateAllTracePoints();
@@ -346,7 +339,7 @@ void Trace::updateSingleTracePoint(TraceLabelPoint_f* tlp,
 
     const auto trace_position =
         lnf->getTracePointPositionFrom(m_axes_bounds, m_x_lim, m_x_scaling,
-                                        m_y_lim, m_y_scaling, data_value) +
+                                       m_y_lim, m_y_scaling, data_value) +
         m_axes_bounds.getPosition();
 
     auto trace_label_bounds =
@@ -355,8 +348,7 @@ void Trace::updateSingleTracePoint(TraceLabelPoint_f* tlp,
     auto trace_label_corner_pos =
         force_corner_position
             ? tlp->trace_label->trace_label_corner_pos
-            : getCornerPosition(m_axes_bounds.getCentre(),
-                                trace_position);
+            : getCornerPosition(m_axes_bounds.getCentre(), trace_position);
 
     switch (trace_label_corner_pos) {
       case TraceLabelCornerPosition::top_left:

--- a/source/package.h
+++ b/source/package.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */

--- a/tests/gui/non_realtime/non_rt_test_app.cpp
+++ b/tests/gui/non_realtime/non_rt_test_app.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
@@ -8,73 +8,68 @@
 #include "test_utils.h"
 
 //==============================================================================
-class NonRTTestApp  : public juce::JUCEApplication
-{
-public:
-    //==============================================================================
-    NonRTTestApp() {}
+class NonRTTestApp : public juce::JUCEApplication {
+ public:
+  //==============================================================================
+  NonRTTestApp() {}
 
-    const juce::String getApplicationName() override       { return JUCE_APPLICATION_NAME_STRING; }
-    const juce::String getApplicationVersion() override    { return JUCE_APPLICATION_VERSION_STRING; }
-    bool moreThanOneInstanceAllowed() override             { return true; }
+  const juce::String getApplicationName() override {
+    return JUCE_APPLICATION_NAME_STRING;
+  }
+  const juce::String getApplicationVersion() override {
+    return JUCE_APPLICATION_VERSION_STRING;
+  }
+  bool moreThanOneInstanceAllowed() override { return true; }
 
-    void initialise (const juce::String& commandLine) override
-    {
-        juce::ignoreUnused (commandLine);
+  void initialise(const juce::String& commandLine) override {
+    juce::ignoreUnused(commandLine);
 
-        mainWindow.reset (new MainWindow (getApplicationName()));
+    mainWindow.reset(new MainWindow(getApplicationName()));
+  }
+
+  void shutdown() override {
+    mainWindow = nullptr;  // (deletes our window)
+  }
+
+  void systemRequestedQuit() override { quit(); }
+
+  void anotherInstanceStarted(const juce::String& commandLine) override {
+    juce::ignoreUnused(commandLine);
+  }
+
+  class MainWindow : public juce::DocumentWindow {
+   public:
+    explicit MainWindow(juce::String name)
+        : DocumentWindow(
+              name,
+              juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(
+                  ResizableWindow::backgroundColourId),
+              DocumentWindow::allButtons) {
+      setUsingNativeTitleBar(true);
+      setContentOwned(&m_test_handler, true);
+
+#if JUCE_IOS || JUCE_ANDROID
+      setFullScreen(true);
+#else
+      setResizable(true, true);
+      centreWithSize(getWidth(), getHeight());
+#endif
+
+      setVisible(true);
     }
 
-    void shutdown() override
-    {
-        mainWindow = nullptr; // (deletes our window)
+    void closeButtonPressed() override {
+      JUCEApplication::getInstance()->systemRequestedQuit();
     }
 
-    void systemRequestedQuit() override
-    {
-        quit();
-    }
+   private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainWindow)
+    TestHandler m_test_handler{TestHandler("non_real_time")};
+  };
 
-    void anotherInstanceStarted (const juce::String& commandLine) override
-    {
-        juce::ignoreUnused (commandLine);
-    }
-	
-    class MainWindow    : public juce::DocumentWindow
-    {
-    public:
-        explicit MainWindow (juce::String name)
-            : DocumentWindow (name,
-                              juce::Desktop::getInstance().getDefaultLookAndFeel()
-                                                          .findColour (ResizableWindow::backgroundColourId),
-                              DocumentWindow::allButtons)
-        {
-            setUsingNativeTitleBar (true);
-            setContentOwned (&m_test_handler, true);
-
-           #if JUCE_IOS || JUCE_ANDROID
-            setFullScreen (true);
-           #else
-            setResizable (true, true);
-            centreWithSize (getWidth(), getHeight());
-           #endif
-
-            setVisible (true);
-        }
-
-        void closeButtonPressed() override
-        {
-            JUCEApplication::getInstance()->systemRequestedQuit();
-        }
-
-    private:
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainWindow)
-        TestHandler m_test_handler{TestHandler("non_real_time")};
-    };
-
-private:
-    std::unique_ptr<MainWindow> mainWindow;
+ private:
+  std::unique_ptr<MainWindow> mainWindow;
 };
 
 //==============================================================================
-START_JUCE_APPLICATION (NonRTTestApp)
+START_JUCE_APPLICATION(NonRTTestApp)

--- a/tests/gui/plot3d/plot3d_test_app.cpp
+++ b/tests/gui/plot3d/plot3d_test_app.cpp
@@ -127,9 +127,9 @@ static std::unique_ptr<juce::Component> makeLinearVsLogScene() {
   };
 
   plot_both(row->add(std::make_unique<cmp::Plot3D>()), "Linear z-axis");
-  plot_both(row->add(std::make_unique<cmp::Plot3D>(
-                cmp::Scaling::linear, cmp::Scaling::linear,
-                cmp::Scaling::logarithmic)),
+  plot_both(row->add(std::make_unique<cmp::Plot3D>(cmp::Scaling::linear,
+                                                   cmp::Scaling::linear,
+                                                   cmp::Scaling::logarithmic)),
             "Logarithmic z-axis");
 
   return row;
@@ -212,8 +212,8 @@ class Plot3DTestHandler : public juce::Component {
   }
 
   void paint(juce::Graphics& g) override {
-    g.fillAll(getLookAndFeel().findColour(
-        juce::ResizableWindow::backgroundColourId));
+    g.fillAll(
+        getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
   }
 
   void resized() override {
@@ -236,8 +236,7 @@ class Plot3DTestHandler : public juce::Component {
     }
 
     for (std::size_t i = 0; i < m_scenes.size(); ++i) {
-      if (juce::String(m_scenes[i].name)
-              .containsIgnoreCase(trimmed))
+      if (juce::String(m_scenes[i].name).containsIgnoreCase(trimmed))
         return static_cast<int>(i);
     }
 
@@ -289,9 +288,8 @@ class Plot3DTestApp : public juce::JUCEApplication {
     MainWindow(juce::String name, const juce::String& commandLine)
         : DocumentWindow(
               name,
-              juce::Desktop::getInstance()
-                  .getDefaultLookAndFeel()
-                  .findColour(ResizableWindow::backgroundColourId),
+              juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(
+                  ResizableWindow::backgroundColourId),
               DocumentWindow::allButtons),
           m_handler(commandLine) {
       setUsingNativeTitleBar(true);

--- a/tests/gui/realtime/rt_test_app.cpp
+++ b/tests/gui/realtime/rt_test_app.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
@@ -8,73 +8,68 @@
 #include "test_utils.h"
 
 //==============================================================================
-class RTTestApp  : public juce::JUCEApplication
-{
-public:
-    //==============================================================================
-    RTTestApp() {}
+class RTTestApp : public juce::JUCEApplication {
+ public:
+  //==============================================================================
+  RTTestApp() {}
 
-    const juce::String getApplicationName() override       { return JUCE_APPLICATION_NAME_STRING; }
-    const juce::String getApplicationVersion() override    { return JUCE_APPLICATION_VERSION_STRING; }
-    bool moreThanOneInstanceAllowed() override             { return true; }
+  const juce::String getApplicationName() override {
+    return JUCE_APPLICATION_NAME_STRING;
+  }
+  const juce::String getApplicationVersion() override {
+    return JUCE_APPLICATION_VERSION_STRING;
+  }
+  bool moreThanOneInstanceAllowed() override { return true; }
 
-    void initialise (const juce::String& commandLine) override
-    {
-        juce::ignoreUnused (commandLine);
+  void initialise(const juce::String& commandLine) override {
+    juce::ignoreUnused(commandLine);
 
-        mainWindow.reset (new MainWindow (getApplicationName()));
+    mainWindow.reset(new MainWindow(getApplicationName()));
+  }
+
+  void shutdown() override {
+    mainWindow = nullptr;  // (deletes our window)
+  }
+
+  void systemRequestedQuit() override { quit(); }
+
+  void anotherInstanceStarted(const juce::String& commandLine) override {
+    juce::ignoreUnused(commandLine);
+  }
+
+  class MainWindow : public juce::DocumentWindow {
+   public:
+    explicit MainWindow(juce::String name)
+        : DocumentWindow(
+              name,
+              juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(
+                  ResizableWindow::backgroundColourId),
+              DocumentWindow::allButtons) {
+      setUsingNativeTitleBar(true);
+      setContentOwned(&m_test_handler, true);
+
+#if JUCE_IOS || JUCE_ANDROID
+      setFullScreen(true);
+#else
+      setResizable(true, true);
+      centreWithSize(getWidth(), getHeight());
+#endif
+
+      setVisible(true);
     }
 
-    void shutdown() override
-    {
-        mainWindow = nullptr; // (deletes our window)
+    void closeButtonPressed() override {
+      JUCEApplication::getInstance()->systemRequestedQuit();
     }
 
-    void systemRequestedQuit() override
-    {
-        quit();
-    }
+   private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainWindow)
+    TestHandler m_test_handler{TestHandler("real_time")};
+  };
 
-    void anotherInstanceStarted (const juce::String& commandLine) override
-    {
-        juce::ignoreUnused (commandLine);
-    }
-	
-    class MainWindow    : public juce::DocumentWindow
-    {
-    public:
-        explicit MainWindow (juce::String name)
-            : DocumentWindow (name,
-                              juce::Desktop::getInstance().getDefaultLookAndFeel()
-                                                          .findColour (ResizableWindow::backgroundColourId),
-                              DocumentWindow::allButtons)
-        {
-            setUsingNativeTitleBar (true);
-            setContentOwned(&m_test_handler, true);
-
-           #if JUCE_IOS || JUCE_ANDROID
-            setFullScreen (true);
-           #else
-            setResizable (true, true);
-            centreWithSize (getWidth(), getHeight());
-           #endif
-
-            setVisible (true);
-        }
-
-        void closeButtonPressed() override
-        {
-            JUCEApplication::getInstance()->systemRequestedQuit();
-        }
-
-    private:
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainWindow)
-        TestHandler m_test_handler{TestHandler("real_time")};
-    };
-
-private:
-    std::unique_ptr<MainWindow> mainWindow;
+ private:
+  std::unique_ptr<MainWindow> mainWindow;
 };
 
 //==============================================================================
-START_JUCE_APPLICATION (RTTestApp)
+START_JUCE_APPLICATION(RTTestApp)

--- a/tests/gui/realtime/rt_tests.cpp
+++ b/tests/gui/realtime/rt_tests.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
@@ -10,21 +10,22 @@
 
 #define PI2 6.28318530718
 
-
 TEST(random_amount_y_data, real_time) {
   ADD_PLOT;
   ADD_TIMER(1000);
 
   GET_TIMER_CB = [=](const int dt_ms) {
     static std::vector<std::vector<float>> y_test_data;
-    size_t points_count = 2 + (size_t)((float(rand()) / float(RAND_MAX)) * 1000.0);
+    size_t points_count =
+        2 + (size_t)((float(rand()) / float(RAND_MAX)) * 1000.0);
     size_t curve_count = 1 + (size_t)((float(rand()) / float(RAND_MAX)) * 10.0);
 
     y_test_data.resize(curve_count);
     for (size_t i = 0; i < curve_count; ++i) {
       y_test_data[i].resize(points_count);
       for (size_t j = 0; j < points_count; ++j) {
-        y_test_data[i][j] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+        y_test_data[i][j] =
+            static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
       }
     }
     PLOT_Y({y_test_data});
@@ -94,7 +95,9 @@ TEST(spread, real_time) {
   const std::vector<cmp::SpreadIndex> spread_indices = {{0, 1}};
   FILL_BETWEEN(spread_indices);
 
-  GET_TIMER_CB = [=](const int dt_ms) { GET_PLOT->plotUpdateYOnly(getYData()); };
+  GET_TIMER_CB = [=](const int dt_ms) {
+    GET_PLOT->plotUpdateYOnly(getYData());
+  };
 }
 
 TEST(random_yx_values, real_time) {
@@ -103,7 +106,8 @@ TEST(random_yx_values, real_time) {
 
   GET_TIMER_CB = [=](const int dt_ms) {
     static std::vector<std::vector<float>> x_test_data, y_test_data;
-    size_t points_count = 2 + (size_t)((float(rand()) / float(RAND_MAX)) * 1000.0);
+    size_t points_count =
+        2 + (size_t)((float(rand()) / float(RAND_MAX)) * 1000.0);
     size_t curve_count = 1 + (size_t)((float(rand()) / float(RAND_MAX)) * 10.0);
 
     x_test_data.resize(curve_count);
@@ -113,7 +117,8 @@ TEST(random_yx_values, real_time) {
       y_test_data[i].resize(points_count);
       for (size_t j = 0; j < points_count; ++j) {
         x_test_data[i][j] = (float)j;  // Linear curve
-        y_test_data[i][j] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+        y_test_data[i][j] =
+            static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
       }
     }
     PLOT_XY({y_test_data}, {x_test_data});

--- a/tests/gui/utils/test_macros.h
+++ b/tests/gui/utils/test_macros.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
@@ -89,4 +89,5 @@
 
 #define CLEAR_TRACE_POINTS GET_PLOT->clearTracePoints();
 
-#define SET_SCALING(X_SCALING, Y_SCALING) GET_PLOT->setScaling(X_SCALING, Y_SCALING);
+#define SET_SCALING(X_SCALING, Y_SCALING) \
+  GET_PLOT->setScaling(X_SCALING, Y_SCALING);

--- a/tests/gui/utils/test_utils.h
+++ b/tests/gui/utils/test_utils.h
@@ -1,14 +1,14 @@
 /**
  * Copyright (c) 2022 Frans Rosencrantz
- * 
+ *
  * This software is released under the MIT License.
  * https://opensource.org/licenses/MIT
  */
 
 #pragma once
 
-#include <juce_gui_extra/juce_gui_extra.h>
 #include <cmp_plot.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 template <class ContainerType>
 static ContainerType& getPlotFromID(
@@ -28,7 +28,10 @@ static ContainerType& getPlotFromID(
 }
 
 static juce::Rectangle<int> getScreenArea() {
-  return juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea;
+  return juce::Desktop::getInstance()
+      .getDisplays()
+      .getPrimaryDisplay()
+      ->userArea;
 }
 
 struct TimerCallback : public juce::Timer {

--- a/tests/unit_tests/cmp_axes3dbox_test.cpp
+++ b/tests/unit_tests/cmp_axes3dbox_test.cpp
@@ -1,6 +1,7 @@
+#include "cmp_axes3dbox.h"
+
 #include <algorithm>
 
-#include "cmp_axes3dbox.h"
 #include "cmp_test_helper.hpp"
 
 /* Tests for the 3D axes box.
@@ -124,8 +125,7 @@ SECTION(Axes3DBoxTest, "3D axes box") {
   }
 
   TEST("Grid lines: logarithmic scaling adds minor lines on any axis") {
-    const auto log_axis =
-        cmp::Axis_f{{1.f, 1000.f}, cmp::Scaling::logarithmic};
+    const auto log_axis = cmp::Axis_f{{1.f, 1000.f}, cmp::Scaling::logarithmic};
     const auto lin_axis = cmp::Axis_f{{0.f, 10.f}, cmp::Scaling::linear};
 
     // A log axis spanning 1..1000 has the minor lines 1..9, 10..90, 100..900
@@ -169,5 +169,4 @@ SECTION(Axes3DBoxTest, "3D axes box") {
     expect(axes_box.getYTicks().empty());
     expect(axes_box.getZTicks().empty());
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_axis_transform_test.cpp
+++ b/tests/unit_tests/cmp_axis_transform_test.cpp
@@ -1,4 +1,5 @@
 #include "cmp_axis_transform.h"
+
 #include "cmp_test_helper.hpp"
 
 /* Tests for the per-axis value <-> pixel transform.
@@ -18,8 +19,8 @@ SECTION(AxisTransformTest, "Axis transform") {
   };
 
   TEST("Linear: value to pixel") {
-    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear},
-                                       0.f, 500.f);
+    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear}, 0.f,
+                                       500.f);
 
     expectNear(transform.toPixel(0.f), 0.f);
     expectNear(transform.toPixel(5.f), 250.f);
@@ -27,8 +28,8 @@ SECTION(AxisTransformTest, "Axis transform") {
   }
 
   TEST("Linear: pixel to value") {
-    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear},
-                                       0.f, 500.f);
+    const cmp::AxisTransform transform({{0.f, 10.f}, cmp::Scaling::linear}, 0.f,
+                                       500.f);
 
     expectNear(transform.fromPixel(0.f), 0.f);
     expectNear(transform.fromPixel(250.f), 5.f);
@@ -36,8 +37,8 @@ SECTION(AxisTransformTest, "Axis transform") {
   }
 
   TEST("Linear: negative limits") {
-    const cmp::AxisTransform transform({{-5.f, 5.f}, cmp::Scaling::linear},
-                                       0.f, 500.f);
+    const cmp::AxisTransform transform({{-5.f, 5.f}, cmp::Scaling::linear}, 0.f,
+                                       500.f);
 
     expectNear(transform.toPixel(-5.f), 0.f);
     expectNear(transform.toPixel(0.f), 250.f);
@@ -66,8 +67,8 @@ SECTION(AxisTransformTest, "Axis transform") {
   }
 
   TEST("Inverted axis: pixel_min > pixel_max (y-axis convention)") {
-    const cmp::AxisTransform linear({{0.f, 10.f}, cmp::Scaling::linear},
-                                    400.f, 0.f);
+    const cmp::AxisTransform linear({{0.f, 10.f}, cmp::Scaling::linear}, 400.f,
+                                    0.f);
 
     expectNear(linear.toPixel(0.f), 400.f);
     expectNear(linear.toPixel(2.5f), 300.f);
@@ -105,5 +106,4 @@ SECTION(AxisTransformTest, "Axis transform") {
       }
     }
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_camera3d_test.cpp
+++ b/tests/unit_tests/cmp_camera3d_test.cpp
@@ -1,4 +1,5 @@
 #include "cmp_camera3d.h"
+
 #include "cmp_test_helper.hpp"
 
 /* Tests for the 3D camera.
@@ -53,8 +54,8 @@ SECTION(Camera3DTest, "3D camera") {
   }
 
   TEST("View transform is a rotation: lengths are preserved") {
-    for (const auto camera :
-         {cmp::Camera3D(), cmp::Camera3D(123.f, -45.f), cmp::Camera3D(0.f, 0.f)}) {
+    for (const auto camera : {cmp::Camera3D(), cmp::Camera3D(123.f, -45.f),
+                              cmp::Camera3D(0.f, 0.f)}) {
       const auto point = cmp::Vec3f{1.f, 2.f, 3.f};
 
       expectNear(camera.toViewSpace(point).length(), point.length());
@@ -76,5 +77,4 @@ SECTION(Camera3DTest, "3D camera") {
     expectNear(camera.getElevationDegrees(), 90.f);
     expectVecNear(camera.toViewSpace({1.f, 2.f, 3.f}), {1.f, 2.f, 3.f});
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_datamodels_test.cpp
+++ b/tests/unit_tests/cmp_datamodels_test.cpp
@@ -1,6 +1,8 @@
 #include "cmp_datamodels.h"
-#include "cmp_test_helper.hpp"
+
 #include <string>
+
+#include "cmp_test_helper.hpp"
 
 using namespace cmp;
 
@@ -19,7 +21,6 @@ class TestObserver : public Observer<int> {
 };
 
 SECTION(ObservableTest, "Observable class tests") {
-
   TEST("Single observer receives updates") {
     // Create an Observable with initial value 0
     Observable<int> observable(ObserverId::XLim, 0);
@@ -82,7 +83,7 @@ SECTION(ObservableTest, "Observable class tests") {
     Observable<std::string> observable(ObserverId::XLim, "initial");
     expectEquals(*(observable.operator->()), std::string("initial"));
 
-    // Modify the value 
+    // Modify the value
     observable = std::string("updated");
     expectEquals(*observable.operator->(), std::string("updated"));
   }
@@ -91,20 +92,22 @@ SECTION(ObservableTest, "Observable class tests") {
     TestObserver observer;
     Observable<int> observable1(ObserverId::XLim, 0);
     Observable<int> observable2(ObserverId::YLim, 0);
-    
+
     observable1.addObserver(observer);
     expectEquals(observer.updateCount, 1);
-    
+
     observable2.addObserver(observer);
     expectEquals(observer.updateCount, 2);
-    
+
     observable1 = 42;
-    expectEquals(static_cast<int>(observer.lastUpdatedId), static_cast<int>(ObserverId::XLim));
+    expectEquals(static_cast<int>(observer.lastUpdatedId),
+                 static_cast<int>(ObserverId::XLim));
     expectEquals(observer.lastValue, 42);
     expectEquals(observer.updateCount, 3);
 
     observable2 = 100;
-    expectEquals(static_cast<int>(observer.lastUpdatedId), static_cast<int>(ObserverId::YLim));
+    expectEquals(static_cast<int>(observer.lastUpdatedId),
+                 static_cast<int>(ObserverId::YLim));
     expectEquals(observer.lastValue, 100);
     expectEquals(observer.updateCount, 4);
   }

--- a/tests/unit_tests/cmp_downsampler_test.cpp
+++ b/tests/unit_tests/cmp_downsampler_test.cpp
@@ -1,147 +1,124 @@
 #include "cmp_downsampler.h"
-#include "cmp_test_helper.hpp"
+
 #include <vector>
 
+#include "cmp_test_helper.hpp"
+
 class DownsamplerTest : public juce::UnitTest {
-public:
-    DownsamplerTest() : juce::UnitTest("DownsamplerTest", "Downsampler") {}
-    
-    void runTest() override {
-        TEST("Empty data") {
-            std::vector<float> x_data;
-            std::vector<std::size_t> indices;
-            cmp::Downsampler<float>::calculateXIndices(
-                cmp::Scaling::linear,
-                {0.f, 1.f},
-                juce::Rectangle<int>(0, 0, 100, 100),
-                x_data,
-                indices
-            );
-            expect(indices.empty());
-        }
+ public:
+  DownsamplerTest() : juce::UnitTest("DownsamplerTest", "Downsampler") {}
 
-        TEST("XY downsampling with spikes") {
-            // Create data with a spike that should be preserved
-            std::vector<float> x_data(1000, 0.0f);
-            std::vector<float> y_data(1000, 0.0f);
-            
-            // Add a spike in the middle
-            const size_t spike_index = 500;
-            y_data[spike_index] = 100.0f;
-            
-            std::vector<std::size_t> x_indices;
-            std::vector<std::size_t> xy_indices;
-            
-            cmp::Downsampler<float>::calculateXIndices(
-                cmp::Scaling::linear,
-                {0.f, 1000.f},
-                juce::Rectangle<int>(0, 0, 100, 100),
-                x_data,
-                x_indices
-            );
-            
-            cmp::Downsampler<float>::calculateXYBasedIdxs(
-                x_indices,
-                y_data,
-                xy_indices
-            );
-            
-            // The spike should be preserved in downsampling
-            expect(std::find(xy_indices.begin(), xy_indices.end(), spike_index) != xy_indices.end());
-        }
-
-        TEST("XY downsampling with alternating values") {
-            std::vector<float> x_data(100);
-            std::vector<float> y_data(100);
-            std::iota(x_data.begin(), x_data.end(), 0.f);
-            
-            // Create alternating high/low values
-            for(size_t i = 0; i < y_data.size(); ++i) {
-                y_data[i] = (i % 2) ? 100.f : 0.f;
-            }
-            
-            std::vector<std::size_t> x_indices;
-            std::vector<std::size_t> xy_indices;
-            
-            cmp::Downsampler<float>::calculateXIndices(
-                cmp::Scaling::linear,
-                {0.f, 100.f},
-                juce::Rectangle<int>(0, 0, 100, 100),
-                x_data,
-                x_indices
-            );
-            
-            cmp::Downsampler<float>::calculateXYBasedIdxs(
-                x_indices,
-                y_data,
-                xy_indices
-            );
-            
-            // Should preserve enough points to show the alternating pattern
-            expectGreaterThan(xy_indices.size(), x_indices.size());
-        }
-
-        TEST("XY downsampling with constant segments") {
-            std::vector<float> x_data = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f};
-            std::vector<float> y_data = {0.f, 0.f, 1.f, 1.f, 0.f, 0.f};
-            
-            std::vector<std::size_t> x_indices;
-            std::vector<std::size_t> xy_indices;
-            
-            cmp::Downsampler<float>::calculateXIndices(
-                cmp::Scaling::linear,
-                {0.f, 5.f},
-                juce::Rectangle<int>(0, 0, 100, 100),
-                x_data,
-                x_indices
-            );
-            
-            cmp::Downsampler<float>::calculateXYBasedIdxs(
-                x_indices,
-                y_data,
-                xy_indices
-            );
-            
-            // Should preserve transition points
-            expect(std::find(xy_indices.begin(), xy_indices.end(), 2) != xy_indices.end());
-            expect(std::find(xy_indices.begin(), xy_indices.end(), 3) != xy_indices.end());
-        }
-
-        TEST("XY downsampling with edge transitions") {
-            std::vector<float> x_data(200);
-            std::vector<float> y_data(200, 0.0f);
-            std::iota(x_data.begin(), x_data.end(), 0.f);
-            
-            // Create a signal with important transitions at edges
-            y_data[0] = 1.0f;   // Start high
-            y_data[1] = 0.0f;   // Immediate drop
-            y_data[198] = 0.0f; // End low
-            y_data[199] = 1.0f; // Final spike
-            
-            std::vector<std::size_t> x_indices;
-            std::vector<std::size_t> xy_indices;
-            
-            cmp::Downsampler<float>::calculateXIndices(
-                cmp::Scaling::linear,
-                {0.f, 200.f},
-                juce::Rectangle<int>(0, 0, 100, 100),
-                x_data,
-                x_indices
-            );
-            
-            cmp::Downsampler<float>::calculateXYBasedIdxs(
-                x_indices,
-                y_data,
-                xy_indices
-            );
-            
-            // Should preserve both start and end transitions
-            expect(std::find(xy_indices.begin(), xy_indices.end(), 0) != xy_indices.end());
-            expect(std::find(xy_indices.begin(), xy_indices.end(), 1) != xy_indices.end());
-            expect(std::find(xy_indices.begin(), xy_indices.end(), 198) != xy_indices.end());
-            expect(std::find(xy_indices.begin(), xy_indices.end(), 199) != xy_indices.end());
-        }
+  void runTest() override {
+    TEST("Empty data") {
+      std::vector<float> x_data;
+      std::vector<std::size_t> indices;
+      cmp::Downsampler<float>::calculateXIndices(
+          cmp::Scaling::linear, {0.f, 1.f},
+          juce::Rectangle<int>(0, 0, 100, 100), x_data, indices);
+      expect(indices.empty());
     }
+
+    TEST("XY downsampling with spikes") {
+      // Create data with a spike that should be preserved
+      std::vector<float> x_data(1000, 0.0f);
+      std::vector<float> y_data(1000, 0.0f);
+
+      // Add a spike in the middle
+      const size_t spike_index = 500;
+      y_data[spike_index] = 100.0f;
+
+      std::vector<std::size_t> x_indices;
+      std::vector<std::size_t> xy_indices;
+
+      cmp::Downsampler<float>::calculateXIndices(
+          cmp::Scaling::linear, {0.f, 1000.f},
+          juce::Rectangle<int>(0, 0, 100, 100), x_data, x_indices);
+
+      cmp::Downsampler<float>::calculateXYBasedIdxs(x_indices, y_data,
+                                                    xy_indices);
+
+      // The spike should be preserved in downsampling
+      expect(std::find(xy_indices.begin(), xy_indices.end(), spike_index) !=
+             xy_indices.end());
+    }
+
+    TEST("XY downsampling with alternating values") {
+      std::vector<float> x_data(100);
+      std::vector<float> y_data(100);
+      std::iota(x_data.begin(), x_data.end(), 0.f);
+
+      // Create alternating high/low values
+      for (size_t i = 0; i < y_data.size(); ++i) {
+        y_data[i] = (i % 2) ? 100.f : 0.f;
+      }
+
+      std::vector<std::size_t> x_indices;
+      std::vector<std::size_t> xy_indices;
+
+      cmp::Downsampler<float>::calculateXIndices(
+          cmp::Scaling::linear, {0.f, 100.f},
+          juce::Rectangle<int>(0, 0, 100, 100), x_data, x_indices);
+
+      cmp::Downsampler<float>::calculateXYBasedIdxs(x_indices, y_data,
+                                                    xy_indices);
+
+      // Should preserve enough points to show the alternating pattern
+      expectGreaterThan(xy_indices.size(), x_indices.size());
+    }
+
+    TEST("XY downsampling with constant segments") {
+      std::vector<float> x_data = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f};
+      std::vector<float> y_data = {0.f, 0.f, 1.f, 1.f, 0.f, 0.f};
+
+      std::vector<std::size_t> x_indices;
+      std::vector<std::size_t> xy_indices;
+
+      cmp::Downsampler<float>::calculateXIndices(
+          cmp::Scaling::linear, {0.f, 5.f},
+          juce::Rectangle<int>(0, 0, 100, 100), x_data, x_indices);
+
+      cmp::Downsampler<float>::calculateXYBasedIdxs(x_indices, y_data,
+                                                    xy_indices);
+
+      // Should preserve transition points
+      expect(std::find(xy_indices.begin(), xy_indices.end(), 2) !=
+             xy_indices.end());
+      expect(std::find(xy_indices.begin(), xy_indices.end(), 3) !=
+             xy_indices.end());
+    }
+
+    TEST("XY downsampling with edge transitions") {
+      std::vector<float> x_data(200);
+      std::vector<float> y_data(200, 0.0f);
+      std::iota(x_data.begin(), x_data.end(), 0.f);
+
+      // Create a signal with important transitions at edges
+      y_data[0] = 1.0f;    // Start high
+      y_data[1] = 0.0f;    // Immediate drop
+      y_data[198] = 0.0f;  // End low
+      y_data[199] = 1.0f;  // Final spike
+
+      std::vector<std::size_t> x_indices;
+      std::vector<std::size_t> xy_indices;
+
+      cmp::Downsampler<float>::calculateXIndices(
+          cmp::Scaling::linear, {0.f, 200.f},
+          juce::Rectangle<int>(0, 0, 100, 100), x_data, x_indices);
+
+      cmp::Downsampler<float>::calculateXYBasedIdxs(x_indices, y_data,
+                                                    xy_indices);
+
+      // Should preserve both start and end transitions
+      expect(std::find(xy_indices.begin(), xy_indices.end(), 0) !=
+             xy_indices.end());
+      expect(std::find(xy_indices.begin(), xy_indices.end(), 1) !=
+             xy_indices.end());
+      expect(std::find(xy_indices.begin(), xy_indices.end(), 198) !=
+             xy_indices.end());
+      expect(std::find(xy_indices.begin(), xy_indices.end(), 199) !=
+             xy_indices.end());
+    }
+  }
 };
 
-static DownsamplerTest downsamplerTest; 
+static DownsamplerTest downsamplerTest;

--- a/tests/unit_tests/cmp_math3d_test.cpp
+++ b/tests/unit_tests/cmp_math3d_test.cpp
@@ -1,4 +1,5 @@
 #include "cmp_math3d.h"
+
 #include "cmp_test_helper.hpp"
 
 SECTION(Math3DTest, "3D math primitives") {
@@ -64,5 +65,4 @@ SECTION(Math3DTest, "3D math primitives") {
     expect(axes.y == cmp::Axis_f({0.f, 2.f}, cmp::Scaling::linear));
     expect(axes.z == cmp::Axis_f({1.f, 1000.f}, cmp::Scaling::logarithmic));
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_pixel_points_test.cpp
+++ b/tests/unit_tests/cmp_pixel_points_test.cpp
@@ -1,8 +1,8 @@
 #include <numeric>
 #include <vector>
 
-#include "cmp_series.h"
 #include "cmp_lookandfeel.h"
+#include "cmp_series.h"
 #include "cmp_test_helper.hpp"
 #include "cmp_utils.h"
 
@@ -104,10 +104,10 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
 
     x_data[2] = 2.5f;
     y_data[2] = 7.5f;
-    lnf.updateXPixelPoints({2u}, cmp::Scaling::linear, {0.f, 10.f},
-                           axes_bounds, x_data, indices, pixel_points);
-    lnf.updateYPixelPoints({2u}, cmp::Scaling::linear, {0.f, 10.f},
-                           axes_bounds, y_data, indices, pixel_points);
+    lnf.updateXPixelPoints({2u}, cmp::Scaling::linear, {0.f, 10.f}, axes_bounds,
+                           x_data, indices, pixel_points);
+    lnf.updateYPixelPoints({2u}, cmp::Scaling::linear, {0.f, 10.f}, axes_bounds,
+                           y_data, indices, pixel_points);
 
     // Index 2 is recalculated from the new data.
     expectNear(pixel_points[2].getX(), 125.f);
@@ -145,10 +145,8 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
     expect(!local_bounds.isEmpty());
 
     // Tolerance of one pixel expressed in data units.
-    const auto x_tolerance =
-        (x_lim.max - x_lim.min) / local_bounds.getWidth();
-    const auto y_tolerance =
-        (y_lim.max - y_lim.min) / local_bounds.getHeight();
+    const auto x_tolerance = (x_lim.max - x_lim.min) / local_bounds.getWidth();
+    const auto y_tolerance = (y_lim.max - y_lim.min) / local_bounds.getHeight();
 
     for (std::size_t i = 0; i < pixel_points.size(); ++i) {
       const auto data_point = cmp::getDataPointFromPixelCoordinate(
@@ -161,5 +159,4 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
                                 y_data[pixel_point_indices[i]], y_tolerance);
     }
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_plot3d_test.cpp
+++ b/tests/unit_tests/cmp_plot3d_test.cpp
@@ -3,8 +3,8 @@
 #include <vector>
 
 #include "cmp_axes3dbox.h"
-#include "cmp_series3d.h"
 #include "cmp_lookandfeel.h"
+#include "cmp_series3d.h"
 #include "cmp_test_helper.hpp"
 
 SECTION(Plot3DClass, "Plot3D class") {
@@ -34,12 +34,9 @@ SECTION(Plot3DClass, "Plot3D class") {
 
     const auto series = getChildComponentHelper<cmp::Series3D>(plot);
     expectEquals(series.size(), 1ul);
-    expectEqualVectors(series[0]->getXData(), x_data1,
-                       expectEqualsLambda);
-    expectEqualVectors(series[0]->getYData(), y_data1,
-                       expectEqualsLambda);
-    expectEqualVectors(series[0]->getZData(), z_data1,
-                       expectEqualsLambda);
+    expectEqualVectors(series[0]->getXData(), x_data1, expectEqualsLambda);
+    expectEqualVectors(series[0]->getYData(), y_data1, expectEqualsLambda);
+    expectEqualVectors(series[0]->getZData(), z_data1, expectEqualsLambda);
     // The colour is assigned from the lookandfeel series colours.
     expect(series[0]->getColour() != juce::Colour());
   }
@@ -49,10 +46,8 @@ SECTION(Plot3DClass, "Plot3D class") {
 
     const auto series = getChildComponentHelper<cmp::Series3D>(plot);
     expectEquals(series.size(), 2ul);
-    expectEqualVectors(series[1]->getXData(), x_data2,
-                       expectEqualsLambda);
-    expectEqualVectors(series[1]->getZData(), z_data2,
-                       expectEqualsLambda);
+    expectEqualVectors(series[1]->getXData(), x_data2, expectEqualsLambda);
+    expectEqualVectors(series[1]->getZData(), z_data2, expectEqualsLambda);
     expect(series[0]->getColour() != series[1]->getColour());
   }
 
@@ -74,8 +69,7 @@ SECTION(Plot3DClass, "Plot3D class") {
     top_view_plot.setView(0.f, 90.f);
     top_view_plot.plot3({x_data1}, {y_data1}, {z_data1});
 
-    const auto series =
-        getChildComponentHelper<cmp::Series3D>(top_view_plot);
+    const auto series = getChildComponentHelper<cmp::Series3D>(top_view_plot);
     expectEquals(series.size(), 1ul);
 
     const auto& pixel_points = series[0]->getPixelPoints();
@@ -122,8 +116,7 @@ SECTION(Plot3DClass, "Plot3D class") {
     plot_tmp.xLim(0.f, 20.f);
     plot_tmp.plot3({x_data1}, {y_data1}, {z_data1});
 
-    const auto series =
-        getChildComponentHelper<cmp::Series3D>(plot_tmp);
+    const auto series = getChildComponentHelper<cmp::Series3D>(plot_tmp);
     const auto& pixel_points = series[0]->getPixelPoints();
     const auto axes_bounds = series[0]->getLocalBounds().toFloat();
 
@@ -162,8 +155,8 @@ SECTION(Plot3DClass, "Plot3D class") {
 
     // The labels are positioned within the plot bounds.
     expect(!plot_tmp.getTitleLabel().getBounds().isEmpty());
-    expect(plot_tmp.getLocalBounds().contains(
-        plot_tmp.getXLabel().getBounds()));
+    expect(
+        plot_tmp.getLocalBounds().contains(plot_tmp.getXLabel().getBounds()));
     expect(plot_tmp.getXLabel().getY() > plot_tmp.getTitleLabel().getY());
   }
 

--- a/tests/unit_tests/cmp_plot_test.cpp
+++ b/tests/unit_tests/cmp_plot_test.cpp
@@ -1,12 +1,13 @@
 #include "cmp_plot.h"
 
 #include <juce_core/juce_core.h>
+
 #include <memory>
 
 #include "cmp_datamodels.h"
+#include "cmp_lookandfeel.h"
 #include "cmp_series.h"
 #include "cmp_test_helper.hpp"
-#include "cmp_lookandfeel.h"
 
 SECTION(PlotClass, "Plot class") {
   auto expectEqualsLambda = [&](auto a, auto b) { expectEquals(a, b); };
@@ -54,7 +55,8 @@ SECTION(PlotClass, "Plot class") {
     auto series = getChildComponentHelper<cmp::Series>(horizontal_plot);
     expectEquals(series.size(), 1ul);
     expect(series[0]->getType() == cmp::SeriesType::horizontal);
-    expectEqualVectors(series[0]->getYData(), {100.f, 100.f}, expectEqualsLambda);
+    expectEqualVectors(series[0]->getYData(), {100.f, 100.f},
+                       expectEqualsLambda);
   }
 
   TEST("Vertical line") {
@@ -63,32 +65,40 @@ SECTION(PlotClass, "Plot class") {
     auto series = getChildComponentHelper<cmp::Series>(vertical_plot);
     expectEquals(series.size(), 1ul);
     expect(series[0]->getType() == cmp::SeriesType::vertical);
-    expectEqualVectors(series[0]->getXData(), {100.f, 100.f}, expectEqualsLambda);
+    expectEqualVectors(series[0]->getXData(), {100.f, 100.f},
+                       expectEqualsLambda);
   }
 
-  TEST ("Update Y data only") {
-    plot.plot({y_data1, y_data2, y_data3}, {x_data_random_1, x_data_random_2, x_data_random_3});
+  TEST("Update Y data only") {
+    plot.plot({y_data1, y_data2, y_data3},
+              {x_data_random_1, x_data_random_2, x_data_random_3});
     plot.plotUpdateYOnly({y_data1, y_data2, y_data3});
     auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 3ul);
-    expectEqualVectors(series[0]->getXData(), x_data_random_1, expectEqualsLambda);
+    expectEqualVectors(series[0]->getXData(), x_data_random_1,
+                       expectEqualsLambda);
     expectEqualVectors(series[0]->getYData(), y_data1, expectEqualsLambda);
-    expectEqualVectors(series[1]->getXData(), x_data_random_2, expectEqualsLambda);
+    expectEqualVectors(series[1]->getXData(), x_data_random_2,
+                       expectEqualsLambda);
     expectEqualVectors(series[1]->getYData(), y_data2, expectEqualsLambda);
-    expectEqualVectors(series[2]->getXData(), x_data_random_3, expectEqualsLambda);
+    expectEqualVectors(series[2]->getXData(), x_data_random_3,
+                       expectEqualsLambda);
     expectEqualVectors(series[2]->getYData(), y_data3, expectEqualsLambda);
   }
 
-  TEST("Set colour"){
+  TEST("Set colour") {
     cmp::Plot plot_tmp;
-    plot_tmp.getLookAndFeel().setColour(cmp::Plot::grid_colour, juce::Colours::red);
-    const auto red = plot_tmp.getLookAndFeel().findColour(cmp::Plot::grid_colour);
+    plot_tmp.getLookAndFeel().setColour(cmp::Plot::grid_colour,
+                                        juce::Colours::red);
+    const auto red =
+        plot_tmp.getLookAndFeel().findColour(cmp::Plot::grid_colour);
     expect(red == juce::Colours::red);
   }
 
-  TEST("Custom look and feel"){
+  TEST("Custom look and feel") {
     cmp::Plot plot_tmp;
-    std::unique_ptr<cmp::PlotLookAndFeel> look_and_feel = std::make_unique<cmp::PlotLookAndFeel>();
+    std::unique_ptr<cmp::PlotLookAndFeel> look_and_feel =
+        std::make_unique<cmp::PlotLookAndFeel>();
     plot_tmp.setLookAndFeel(look_and_feel.get());
     expect(&plot_tmp.getLookAndFeel() == look_and_feel.get());
     plot_tmp.setLookAndFeel(nullptr);

--- a/tests/unit_tests/cmp_projector3d_test.cpp
+++ b/tests/unit_tests/cmp_projector3d_test.cpp
@@ -1,6 +1,7 @@
+#include "cmp_projector3d.h"
+
 #include <vector>
 
-#include "cmp_projector3d.h"
 #include "cmp_test_helper.hpp"
 
 /* Tests for the 3D -> 2D projector.
@@ -18,10 +19,9 @@ SECTION(Projector3DTest, "3D projector") {
 
   const auto axes_bounds = juce::Rectangle<int>(0, 0, 500, 400);
 
-  const auto linear_axes =
-      cmp::Axes3{{{0.f, 10.f}, cmp::Scaling::linear},
-                 {{0.f, 10.f}, cmp::Scaling::linear},
-                 {{0.f, 10.f}, cmp::Scaling::linear}};
+  const auto linear_axes = cmp::Axes3{{{0.f, 10.f}, cmp::Scaling::linear},
+                                      {{0.f, 10.f}, cmp::Scaling::linear},
+                                      {{0.f, 10.f}, cmp::Scaling::linear}};
 
   TEST("Top view: x maps across the width, y up the height") {
     const cmp::Camera3D top_view(0.f, 90.f);
@@ -57,7 +57,8 @@ SECTION(Projector3DTest, "3D projector") {
 
     // One decade per third of the series height.
     expectPointNear(projector.toPixel({5.f, 5.f, 1.f}), {250.f, 400.f});
-    expectPointNear(projector.toPixel({5.f, 5.f, 10.f}), {250.f, 400.f * 2.f / 3.f});
+    expectPointNear(projector.toPixel({5.f, 5.f, 10.f}),
+                    {250.f, 400.f * 2.f / 3.f});
     expectPointNear(projector.toPixel({5.f, 5.f, 100.f}), {250.f, 400.f / 3.f});
     expectPointNear(projector.toPixel({5.f, 5.f, 1000.f}), {250.f, 0.f});
   }
@@ -73,7 +74,8 @@ SECTION(Projector3DTest, "3D projector") {
     // x maps across the width, one decade per third.
     expectPointNear(projector.toPixel({1.f, 5.f, 5.f}), {0.f, 200.f});
     expectPointNear(projector.toPixel({10.f, 5.f, 5.f}), {500.f / 3.f, 200.f});
-    expectPointNear(projector.toPixel({100.f, 5.f, 5.f}), {500.f * 2.f / 3.f, 200.f});
+    expectPointNear(projector.toPixel({100.f, 5.f, 5.f}),
+                    {500.f * 2.f / 3.f, 200.f});
     expectPointNear(projector.toPixel({1000.f, 5.f, 5.f}), {500.f, 200.f});
   }
 
@@ -87,14 +89,14 @@ SECTION(Projector3DTest, "3D projector") {
 
     // y maps up the height (inverted), one decade per third.
     expectPointNear(projector.toPixel({5.f, 1.f, 5.f}), {250.f, 400.f});
-    expectPointNear(projector.toPixel({5.f, 10.f, 5.f}), {250.f, 400.f * 2.f / 3.f});
+    expectPointNear(projector.toPixel({5.f, 10.f, 5.f}),
+                    {250.f, 400.f * 2.f / 3.f});
     expectPointNear(projector.toPixel({5.f, 100.f, 5.f}), {250.f, 400.f / 3.f});
     expectPointNear(projector.toPixel({5.f, 1000.f, 5.f}), {250.f, 0.f});
   }
 
   TEST("Default view: the data cube fills the axes bounds") {
-    const cmp::Projector3D projector(linear_axes, cmp::Camera3D(),
-                                     axes_bounds);
+    const cmp::Projector3D projector(linear_axes, cmp::Camera3D(), axes_bounds);
 
     auto min_pixel = juce::Point<float>(1e9f, 1e9f);
     auto max_pixel = juce::Point<float>(-1e9f, -1e9f);
@@ -132,5 +134,4 @@ SECTION(Projector3DTest, "3D projector") {
     expectPointNear(pixel_points[1], {250.f, 200.f});
     expectPointNear(pixel_points[2], {500.f, 0.f});
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_series3d_test.cpp
+++ b/tests/unit_tests/cmp_series3d_test.cpp
@@ -1,6 +1,7 @@
+#include "cmp_series3d.h"
+
 #include <vector>
 
-#include "cmp_series3d.h"
 #include "cmp_lookandfeel.h"
 #include "cmp_projector3d.h"
 #include "cmp_test_helper.hpp"
@@ -46,8 +47,7 @@ SECTION(Series3DTest, "3D series") {
     const auto& pixel_points = series.getPixelPoints();
     expectEquals(pixel_points.size(), x_data.size());
 
-    const cmp::Projector3D projector(axes, top_view,
-                                     series.getLocalBounds());
+    const cmp::Projector3D projector(axes, top_view, series.getLocalBounds());
     for (std::size_t i = 0; i < pixel_points.size(); ++i) {
       expectPointNear(pixel_points[i],
                       projector.toPixel({x_data[i], y_data[i], z_data[i]}));
@@ -94,5 +94,4 @@ SECTION(Series3DTest, "3D series") {
     // Setting one attribute does not reset the colour.
     expect(series.getColour() == juce::Colours::red);
   }
-}
-;
+};

--- a/tests/unit_tests/cmp_test_helper.hpp
+++ b/tests/unit_tests/cmp_test_helper.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <juce_core/juce_core.h>
-#include "cmp_plot.h"
 
+#include "cmp_plot.h"
 
 template <typename ComponentType>
 static std::vector<ComponentType*> getChildComponentHelper(

--- a/tests/unit_tests/cmp_trace_test.cpp
+++ b/tests/unit_tests/cmp_trace_test.cpp
@@ -1,12 +1,13 @@
-#include "cmp_plot.h"
+#include "cmp_trace.h"
 
 #include <juce_core/juce_core.h>
+
 #include <memory>
 
 #include "cmp_datamodels.h"
-#include "cmp_series.h"
 #include "cmp_lookandfeel.h"
-#include "cmp_trace.h"
+#include "cmp_plot.h"
+#include "cmp_series.h"
 #include "cmp_test_helper.hpp"
 #include "cmp_utils.h"
 
@@ -101,11 +102,11 @@ SECTION(MoveSelectedTracePointsTest, "Move selected trace points") {
   auto makeMouseEvent = [](juce::Component* component,
                            const juce::Point<float> position,
                            const bool was_dragged) {
-    return juce::MouseEvent(
-        juce::Desktop::getInstance().getMainMouseSource(), position,
-        juce::ModifierKeys::leftButtonModifier, 0.f, 0.f, 0.f, 0.f, 0.f,
-        component, component, juce::Time::getCurrentTime(), position,
-        juce::Time::getCurrentTime(), 1, was_dragged);
+    return juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(),
+                            position, juce::ModifierKeys::leftButtonModifier,
+                            0.f, 0.f, 0.f, 0.f, 0.f, component, component,
+                            juce::Time::getCurrentTime(), position,
+                            juce::Time::getCurrentTime(), 1, was_dragged);
   };
 
   TEST("Drag a selected trace point: logarithmic x, linear y") {
@@ -156,18 +157,16 @@ SECTION(MoveSelectedTracePointsTest, "Move selected trace points") {
     // The expected data movement converts the axes-area-local pixel
     // positions with axes-area-local (zero-origin) bounds.
     const auto local_bounds = axes_bounds.withZeroOrigin().toFloat();
-    const auto d_x = cmp::getXDataFromXPixelCoordinate(
-                         new_pos_local.getX(), local_bounds, x_lim,
-                         cmp::Scaling::logarithmic) -
-                     cmp::getXDataFromXPixelCoordinate(
-                         prev_pos_local.getX(), local_bounds, x_lim,
-                         cmp::Scaling::logarithmic);
-    const auto d_y = cmp::getYDataFromYPixelCoordinate(
-                         new_pos_local.getY(), local_bounds, y_lim,
-                         cmp::Scaling::linear) -
-                     cmp::getYDataFromYPixelCoordinate(
-                         prev_pos_local.getY(), local_bounds, y_lim,
-                         cmp::Scaling::linear);
+    const auto d_x =
+        cmp::getXDataFromXPixelCoordinate(new_pos_local.getX(), local_bounds,
+                                          x_lim, cmp::Scaling::logarithmic) -
+        cmp::getXDataFromXPixelCoordinate(prev_pos_local.getX(), local_bounds,
+                                          x_lim, cmp::Scaling::logarithmic);
+    const auto d_y =
+        cmp::getYDataFromYPixelCoordinate(new_pos_local.getY(), local_bounds,
+                                          y_lim, cmp::Scaling::linear) -
+        cmp::getYDataFromYPixelCoordinate(prev_pos_local.getY(), local_bounds,
+                                          y_lim, cmp::Scaling::linear);
     const auto expected_x = x_data[1] + d_x;
     const auto expected_y = y_data[1] + d_y;
 
@@ -177,8 +176,7 @@ SECTION(MoveSelectedTracePointsTest, "Move selected trace points") {
 
     expectWithinAbsoluteError(series[0]->getXData()[1], expected_x,
                               1e-3f * expected_x);
-    expectWithinAbsoluteError(series[0]->getYData()[1], expected_y,
-                              1e-3f);
+    expectWithinAbsoluteError(series[0]->getYData()[1], expected_y, 1e-3f);
 
     // The other data points are untouched.
     expectEquals(series[0]->getXData()[0], x_data[0]);

--- a/tests/unit_tests/cmp_utils_test.cpp
+++ b/tests/unit_tests/cmp_utils_test.cpp
@@ -1,16 +1,16 @@
+#include "cmp_utils.h"
+
 #include <string>
 #include <vector>
 
 #include "cmp_test_helper.hpp"
 #include "juce_core/system/juce_PlatformDefs.h"
 
-#include "cmp_utils.h"
-
 SECTION(UtilsTest, "Utils class"){
 
-TEST("Generate ticks: 0.0f -> 1000.0f"){
-    std::vector<float> result = cmp::TicksGenerator::generateTicks(
-        0.0f, 1000.0f, 10, std::vector<float>());
+    TEST("Generate ticks: 0.0f -> 1000.0f"){
+        std::vector<float> result = cmp::TicksGenerator::generateTicks(
+            0.0f, 1000.0f, 10, std::vector<float>());
 
 std::vector<float> expected = {
     -500.0f, -400.0f, -300.0f, -200.0f, -100.0f, 0.0f,    100.0f,
@@ -224,8 +224,8 @@ SECTION(CoordinateConversionTest, "Coordinate conversions") {
   }
 
   TEST("X-data to pixel: logarithmic") {
-    const auto [x_scale, x_offset] =
-        cmp::getXScaleAndOffset(300.f, {1.f, 1000.f}, cmp::Scaling::logarithmic);
+    const auto [x_scale, x_offset] = cmp::getXScaleAndOffset(
+        300.f, {1.f, 1000.f}, cmp::Scaling::logarithmic);
 
     expectNear(cmp::getXPixelValueLogarithmic(1.f, x_scale, x_offset), 0.f);
     expectNear(cmp::getXPixelValueLogarithmic(10.f, x_scale, x_offset), 100.f);
@@ -243,8 +243,8 @@ SECTION(CoordinateConversionTest, "Coordinate conversions") {
   }
 
   TEST("Y-data to pixel: logarithmic") {
-    const auto [y_scale, y_offset] =
-        cmp::getYScaleAndOffset(300.f, {1.f, 1000.f}, cmp::Scaling::logarithmic);
+    const auto [y_scale, y_offset] = cmp::getYScaleAndOffset(
+        300.f, {1.f, 1000.f}, cmp::Scaling::logarithmic);
 
     expectNear(cmp::getYPixelValueLogarithmic(1.f, y_scale, y_offset), 300.f);
     expectNear(cmp::getYPixelValueLogarithmic(100.f, y_scale, y_offset), 100.f);
@@ -316,5 +316,4 @@ SECTION(CoordinateConversionTest, "Coordinate conversions") {
       }
     }
   }
-}
-;
+};


### PR DESCRIPTION
## Apply clang-format (Google)

Adds a committed `.clang-format` (`BasedOnStyle: Google`) and reformats all project C++ sources/headers (excluding `externals/` JUCE).

- **Pure formatting** — no behavioural change.
- 62 files reformatted + the new `.clang-format`.
- Builds clean; all 114 unit tests pass; 2D/3D examples and GUI apps build.

With the config committed, contributors and CI can enforce the style going forward.

---
_Best reviewed with whitespace-insensitive diff (`?w=1` on GitHub)._
