### PR TITLE
Public API cleanup: docs, English, and set* naming

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,10 @@
   x, y and attributes (order is x, y).
 - **Breaking:** `Plot3D::plot3` now takes `std::vector<Series3DData>` instead
   of separate x, y and z vectors.
+- **Breaking:** Renamed the axis-limit setters to follow the `set*` convention:
+  `xLim`/`yLim` → `setXLim`/`setYLim` (and `Plot3D::zLim` → `setZLim`).
+- **Breaking:** Fixed a typo in a public colour id:
+  `ColourIds::transluent_grid_colour` → `translucent_grid_colour`.
 
 ## 1.3.0 (2024-9-12)
 

--- a/examples/example_apps/lim/lim.h
+++ b/examples/example_apps/lim/lim.h
@@ -25,8 +25,8 @@ class lim : public juce::Component {
     m_plot.plot({.y = {15, 3, 7, 9, 13}});
 
     // Set x and y limits
-    m_plot.xLim(-1.0f, 3.4f);
-    m_plot.yLim(3.14f, 42.0f);
+    m_plot.setXLim(-1.0f, 3.4f);
+    m_plot.setYLim(3.14f, 42.0f);
   };
 
   void resized() override {

--- a/examples/example_apps/lookandfeel_timeline/lookandfeel_timeline.h
+++ b/examples/example_apps/lookandfeel_timeline/lookandfeel_timeline.h
@@ -35,8 +35,8 @@ class lookandfeel_timeline : public juce::Component {
     m_plot.plot({.x = {-100, 20, 40, 50, 220}, .y = {0, 3, 7, 9, 2.5}});
 
     // Setting x/y limes.
-    m_plot.xLim(-10.f, 200.f);
-    m_plot.yLim(-10.f, 10.f);
+    m_plot.setXLim(-10.f, 200.f);
+    m_plot.setYLim(-10.f, 10.f);
 
     m_plot.setGridType(GridType::grid_translucent);
   };

--- a/extras/include/cmp_extras.hpp
+++ b/extras/include/cmp_extras.hpp
@@ -54,7 +54,7 @@ class TerrenceLookAndFeel : public cmp::PlotLookAndFeelTimeline {
 
   void overridePlotColours() noexcept override {
     setColour(Plot::grid_colour, juce::Colour(0xff181818));
-    setColour(Plot::transluent_grid_colour, juce::Colour(0xff252525));
+    setColour(Plot::translucent_grid_colour, juce::Colour(0xff252525));
     // Override more colurs...
   };
 };

--- a/extras/source/cmp_extras.cpp
+++ b/extras/source/cmp_extras.cpp
@@ -256,6 +256,6 @@ void PlotLookAndFeelTimeline::drawBackground(
 
 void PlotLookAndFeelTimeline::overridePlotColours() noexcept {
   setColour(Plot::grid_colour, juce::Colour(0xff181818));
-  setColour(Plot::transluent_grid_colour, juce::Colour(0xff252525));
+  setColour(Plot::translucent_grid_colour, juce::Colour(0xff252525));
 }
 }  // namespace cmp

--- a/include/include/cmp_datamodels.h
+++ b/include/include/cmp_datamodels.h
@@ -88,19 +88,19 @@ typedef std::function<void(const SeriesDataViewList& series)>
 
 /** Enum to define the scaling of an axis. */
 enum class Scaling : uint32_t {
-  linear,     /** Linear scaling of the series. */
-  logarithmic /** Logarithmic scaling of the series. */
+  linear,     /**< Linear scaling of the series. */
+  logarithmic /**< Logarithmic scaling of the series. */
 };
 
 /** Enum to define the type of downsampling. */
 enum class DownsamplingType : uint32_t {
-  no_downsampling, /** No downsampling. Slow when plotting alot of values. */
-  x_downsampling,  /** Downsampling only based on the x-values, makes sure that
+  no_downsampling, /**< No downsampling. Slow when plotting a lot of values. */
+  x_downsampling,  /**< Downsampling only based on the x-values, makes sure that
                     there is only one plotted value per x-pixel value. Fastest,
                     but will discard x-values that are located with the same
                     x-pixel value near each other. Recommended for real-time
                     plotting. */
-  xy_downsampling, /** Skips x- & y-values that shares the same pixel on the
+  xy_downsampling, /**< Skips x- & y-values that share the same pixel on the
                       screen. It's quicker than 'no_downsampling' but slower
                       than 'x_downsampling'. */
 };
@@ -140,46 +140,46 @@ constexpr enum UserInput operator|(const enum UserInput selfValue,
 /** Enum to define a type of action that will occur for a input. */
 enum class UserInputAction : uint32_t {
   /** Tracepoint related actions. */
-  create_tracepoint,                /** Creates a tracepoint. */
-  move_tracepoint_to_closest_point, /** Move a tracepoint to closest point to
+  create_tracepoint,                /**< Creates a tracepoint. */
+  move_tracepoint_to_closest_point, /**< Move a tracepoint to closest point to
                                        the mouse. */
-  move_tracepoint_label,            /** Move a tracepoint label. */
-  move_selected_trace_points,       /** Move a pixel point. */
-  select_tracepoint,                /** Selecting a tracepoint. */
-  select_tracepoints_within_selected_area, /** Selecting multiple tracepoints.
+  move_tracepoint_label,            /**< Move a tracepoint label. */
+  move_selected_trace_points,       /**< Move a pixel point. */
+  select_tracepoint,                /**< Selecting a tracepoint. */
+  select_tracepoints_within_selected_area, /**< Selecting multiple tracepoints.
                                             */
-  deselect_tracepoint,                     /** Deselecting a tracepoint. */
+  deselect_tracepoint,                     /**< Deselecting a tracepoint. */
 
   /** Zoom related actions. */
-  zoom_selected_area, /** Zoom in on selected area. */
-  zoom_in,            /** Zoom in. */
-  zoom_out,           /** Zoom out. */
-  zoom_reset,         /** Reset the zoom. */
+  zoom_selected_area, /**< Zoom in on selected area. */
+  zoom_in,            /**< Zoom in. */
+  zoom_out,           /**< Zoom out. */
+  zoom_reset,         /**< Reset the zoom. */
 
   /** Selection area related actions. */
-  select_area_start, /** Set start positon for selected area. */
-  select_area_draw,  /** Set end position of selected are and draw the area. */
+  select_area_start, /**< Set start positon for selected area. */
+  select_area_draw,  /**< Set end position of selected area and draw it. */
 
   /** Pixel point related actions. */
-  create_movable_pixel_point, /** Create a movable pixel point. */
-  remove_movable_pixel_point, /** Remove a pixel point. */
+  create_movable_pixel_point, /**< Create a movable pixel point. */
+  remove_movable_pixel_point, /**< Remove a pixel point. */
 
   /** Legend related actions. */
-  move_legend, /** Move a legend. */
+  move_legend, /**< Move a legend. */
 
   /** Panning */
-  panning, /** Panning. */
+  panning, /**< Panning. */
 
   /** No action */
-  none /** No action. */
+  none /**< No action. */
 };
 
 /** Enum to define if the mouse has just start currently dragging or does not
  * drag. */
 enum class MouseDragState : uint32_t {
-  start, /** Start of a mouse drag. */
-  drag,  /** Mouse is currently dragging. */
-  none   /** No drag state. */
+  start, /**< Start of a mouse drag. */
+  drag,  /**< Mouse is currently dragging. */
+  none   /**< No drag state. */
 };
 
 /** Enum to define when the tracepoint/Label should be visible or not. */
@@ -393,10 +393,10 @@ struct Marker {
   /** Contructor marker type only. */
   Marker(const Marker::Type t) : type{t} {};
 
-  /** Marker outline color. */
+  /** Marker outline colour. */
   std::optional<juce::Colour> EdgeColour;
 
-  /** Marker interior color. */
+  /** Marker interior colour. */
   std::optional<juce::Colour> FaceColour;
 
   /** PathStrokeType used when drawing the edge line of the marker. */

--- a/include/include/cmp_datamodels.h
+++ b/include/include/cmp_datamodels.h
@@ -157,7 +157,7 @@ enum class UserInputAction : uint32_t {
   zoom_reset,         /**< Reset the zoom. */
 
   /** Selection area related actions. */
-  select_area_start, /**< Set start positon for selected area. */
+  select_area_start, /**< Set start position for selected area. */
   select_area_draw,  /**< Set end position of selected area and draw it. */
 
   /** Pixel point related actions. */

--- a/include/include/cmp_lookandfeel_base.h
+++ b/include/include/cmp_lookandfeel_base.h
@@ -125,7 +125,7 @@ class PlotLookAndFeelBase : public juce::LookAndFeel_V4 {
   virtual CONSTEXPR20 int getAxisLabelDistanceFromAxesBound(
       const int label_height) const noexcept = 0;
 
-  /** Get the bounds of the componenet (Local bounds). */
+  /** Get the bounds of the component (Local bounds). */
   virtual CONSTEXPR20 juce::Rectangle<int> getPlotBounds(
       juce::Rectangle<int> bounds) const noexcept = 0;
 

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -37,11 +37,15 @@ namespace cmp {
  */
 class Plot : public juce::Component {
  public:
-  /** Destructor, making sure to set the lookandfeel in all subcomponenets to
+  /** Destructor, making sure to set the lookandfeel in all subcomponents to
    * nullptr. */
   ~Plot();
 
-  /* Constructor **/
+  /**
+   * @brief Construct a 2-D plot with the given per-axis scaling.
+   * @param x_scaling linear or logarithmic scaling for the x-axis
+   * @param y_scaling linear or logarithmic scaling for the y-axis
+   */
   Plot(const Scaling x_scaling = Scaling::linear,
        const Scaling y_scaling = Scaling::linear);
 
@@ -132,11 +136,11 @@ class Plot : public juce::Component {
   /** @brief Fill the area between two data lines
    *
    * Steps to use:
-   * 1. Draw series using plot() or realTimePlot()
+   * 1. Draw series using plot() or plotUpdateYOnly()
    * 2. Call this function to fill area between specified lines
    *
    * @param spread_indices Indices of series to fill between
-   * @param fill_area_colours Colors for filled areas (uses ColourIdsSeries if
+   * @param fill_area_colours Colours for filled areas (uses ColourIdsSeries if
    * empty)
    */
   void fillBetween(const std::vector<SpreadIndex> &spread_indices,
@@ -164,7 +168,6 @@ class Plot : public juce::Component {
    * PixelPointMoveType::none.
    *
    * @param move_points_type the type of pixel point movement.
-   * @return void.
    */
   void setMovePointsType(const PixelPointMoveType move_points_type);
 
@@ -175,7 +178,6 @@ class Plot : public juce::Component {
    *
    * @see cmp::SeriesChangedCallback for more information.
    * @param series_changed_callback the callback function.
-   * @return void.
    */
   void setSeriesDataChangedCallback(
       SeriesChangedCallback series_changed_callback);
@@ -196,7 +198,7 @@ class Plot : public juce::Component {
    * @brief Set x & y-axis scaling
    * @param x_scaling x-axis scaling
    * @param y_scaling y-axis scaling
-   * @see cmp::Scaling in cmp:datamodels.h
+   * @see cmp::Scaling in cmp_datamodels.h
    */
   void setScaling(Scaling x_scaling, Scaling y_scaling) noexcept;
 
@@ -233,34 +235,30 @@ class Plot : public juce::Component {
    *  the y-data.
    *
    *  @param y_labels text for the labels displayed as the y-axis
-   *  @return void.
    */
   void setYTickLabels(const std::vector<std::string> &y_labels);
 
   /** @brief Set the ticks values
    *
-   *  Use custom ticks to draw the grid lines and tick labels where you wanted.
+   *  Use custom ticks to draw the grid lines and tick labels where you want.
    *
-   *  @param x_ticks x-postions of ticks
-   *  @return void.
+   *  @param x_ticks x-positions of ticks
    */
   void setXTicks(const std::vector<float> &x_ticks);
 
   /** @brief Set the ticks values
    *
-   *  Use custom ticks to draw the grid lines and tick labels where you wanted.
+   *  Use custom ticks to draw the grid lines and tick labels where you want.
    *
-   *  @param y_ticks y-postions of ticks
-   *  @return void.
+   *  @param y_ticks y-positions of ticks
    */
   void setYTicks(const std::vector<float> &y_ticks);
 
   /** @brief Enables grid or tiny grid
    *
-   *  Turn on grids or tiny grids. @see GridType in cmp:datamodels.h.
+   *  Turn on grids or tiny grids. @see GridType in cmp_datamodels.h.
    *
-   *  @param grid_type typ of grid to be drawn.
-   *  @return void.
+   *  @param grid_type type of grid to be drawn.
    */
   void setGridType(const GridType grid_type);
 
@@ -268,18 +266,15 @@ class Plot : public juce::Component {
    *
    * Removes all tracepoints.
    *
-   * @return void.
    */
   void clearTracePoints() noexcept;
 
   /** @brief Set Legend
    *
-   *  Set descriptions for each series. The label 'label1..N' will be used if
-   *  fewers numbers of series_descriptions are provided than existing numbers
-   * of series.
+   *  Set a description for each series. The label 'label1..N' is used when
+   *  fewer descriptions are provided than there are series.
    *
    *  @param series_descriptions description of the series
-   *  @return void.
    */
   void setLegend(const std::vector<std::string> &series_descriptions);
 
@@ -287,7 +282,7 @@ class Plot : public juce::Component {
 
   /** @brief This lambda is triggered when a tracepoint value is changed.
    *
-   * @param current_plot poiter to this plot.
+   * @param current_plot pointer to this plot.
    * @param previous_trace_point previous tracepoint value.
    * @param new_trace_point the new tracepoint value.
    */
@@ -298,52 +293,53 @@ class Plot : public juce::Component {
 
   //==============================================================================
 
-  /** @brief Color IDs for customizing plot appearance
+  /** @brief Colour IDs for customizing plot appearance
    * @details These IDs can be used with Component::setColour() or
-   * LookAndFeel::setColour() to customize colors of various plot elements.
-   * @note All color IDs should be passed to setColour() along with the desired
-   * Color value
+   * LookAndFeel::setColour() to customize colours of various plot elements.
+   * @note All colour IDs should be passed to setColour() along with the desired
+   * Colour value
    * @see Component::setColour
    * @see Component::findColour
    * @see LookAndFeel::setColour
    */
   enum ColourIds : int {
-    background_colour,        /** Colour of the background. */
-    grid_colour,              /** Colour of the grids. */
-    transluent_grid_colour,   /** Colour of the transulent grids. */
-    x_grid_label_colour,      /** Colour of the label for each x-grid line. */
-    y_grid_label_colour,      /** Colour of the label for each y-grid line. */
-    frame_colour,             /** Colour of the frame around the axes area. */
-    x_label_colour,           /** Colour of the text on the x-axis. */
-    y_label_colour,           /** Colour of the label on the y-axis. */
-    title_label_colour,       /** Colour of the title label. */
-    trace_background_colour,  /** Colour of the trace background colour. */
-    trace_label_frame_colour, /** Colour of the trace label frame. */
-    trace_label_colour,       /** Colour of the trace label. */
-    trace_point_colour,       /** Colour of the trace point colour. */
-    trace_point_frame_colour, /** Colour of the trace point frame colour. */
-    legend_label_colour,      /** Colour of the legend label(s). */
-    legend_background_colour, /** Colour of the legend background. */
-    zoom_frame_colour         /** Colour of the dashed zoom rectangle. */
+    background_colour,        /**< Colour of the background. */
+    grid_colour,              /**< Colour of the grids. */
+    transluent_grid_colour,   /**< Colour of the translucent grids. */
+    x_grid_label_colour,      /**< Colour of the label for each x-grid line. */
+    y_grid_label_colour,      /**< Colour of the label for each y-grid line. */
+    frame_colour,             /**< Colour of the frame around the axes area. */
+    x_label_colour,           /**< Colour of the text on the x-axis. */
+    y_label_colour,           /**< Colour of the label on the y-axis. */
+    title_label_colour,       /**< Colour of the title label. */
+    trace_background_colour,  /**< Colour of the trace background colour. */
+    trace_label_frame_colour, /**< Colour of the trace label frame. */
+    trace_label_colour,       /**< Colour of the trace label. */
+    trace_point_colour,       /**< Colour of the trace point colour. */
+    trace_point_frame_colour, /**< Colour of the trace point frame colour. */
+    legend_label_colour,      /**< Colour of the legend label(s). */
+    legend_background_colour, /**< Colour of the legend background. */
+    zoom_frame_colour         /**< Colour of the dashed zoom rectangle. */
   };
 
   /** @brief A set of colour IDs to use to change the colour of each plot
    * line.*/
   enum ColourIdsSeries : int {
-    first_series_colour = (1u << 16u), /** Colour of the first series. */
-    second_series_colour,              /** Colour of the second series. */
-    third_series_colour,               /** Colour of the third series. */
-    fourth_series_colour,              /** Colour of the fourth series. */
-    fifth_series_colour,               /** Colour of the fifth series. */
-    sixth_series_colour                /** Colour of the sixth series. */
+    first_series_colour = (1u << 16u), /**< Colour of the first series. */
+    second_series_colour,              /**< Colour of the second series. */
+    third_series_colour,               /**< Colour of the third series. */
+    fourth_series_colour,              /**< Colour of the fourth series. */
+    fifth_series_colour,               /**< Colour of the fifth series. */
+    sixth_series_colour                /**< Colour of the sixth series. */
   };
 
   /**
-   *   These methods define a interface for the LookAndFeel class of juce.
-   *   The Plot class needs a LookAndFeel, that implements these methods.
-   *   The dimension-agnostic part of the interface is defined in
-   *   \see PlotLookAndFeelBase; this class adds the 2D-specific methods.
-   *   The default implementation can be seen in \see cmp_lookandfeelmethods.h
+   * @brief The 2D-specific look-and-feel interface for the Plot class.
+   *
+   * A Plot needs a juce::LookAndFeel that implements these methods. The
+   * dimension-agnostic part of the interface is defined in
+   * @ref PlotLookAndFeelBase; this class adds the 2D-specific methods. The
+   * default implementation is @ref PlotLookAndFeel in cmp_lookandfeel.h.
    */
   class LookAndFeelMethods : public PlotLookAndFeelBase {
    public:

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -54,14 +54,14 @@ class Plot : public juce::Component {
    * @param min minimum value
    * @param max maximum value
    */
-  void xLim(const float min, const float max);
+  void setXLim(const float min, const float max);
 
   /**
    * @brief Set the Y-limits
    * @param min minimum value
    * @param max maximum value
    */
-  void yLim(const float min, const float max);
+  void setYLim(const float min, const float max);
 
   /**
    * @brief Plot one or more series.
@@ -211,11 +211,11 @@ class Plot : public juce::Component {
   /**
    * @brief Set trace-point
    *
-   * Set a trace-point to the point on a series closest the given
-   * coordinate. The tracepoint will be removed if it already exists.
+   * Set a trace-point to the point on a series closest to the given
+   * coordinate. The tracepoint is removed if it already exists.
    *
-   * @param trace_point_coordinate the coordinate of where the trace-point is
-   * wish to be set
+   * @param trace_point_coordinate the coordinate where the trace-point should
+   * be set
    */
   void setTracePoint(const juce::Point<float> &trace_point_coordinate);
 
@@ -305,7 +305,7 @@ class Plot : public juce::Component {
   enum ColourIds : int {
     background_colour,        /**< Colour of the background. */
     grid_colour,              /**< Colour of the grids. */
-    transluent_grid_colour,   /**< Colour of the translucent grids. */
+    translucent_grid_colour,   /**< Colour of the translucent grids. */
     x_grid_label_colour,      /**< Colour of the label for each x-grid line. */
     y_grid_label_colour,      /**< Colour of the label for each y-grid line. */
     frame_colour,             /**< Colour of the frame around the axes area. */

--- a/include/include/cmp_plot3d.h
+++ b/include/include/cmp_plot3d.h
@@ -106,7 +106,7 @@ class Plot3D : public juce::Component {
    * @param min minimum value
    * @param max maximum value
    */
-  void xLim(const float min, const float max);
+  void setXLim(const float min, const float max);
 
   /**
    * @brief Set the Y-limits
@@ -114,7 +114,7 @@ class Plot3D : public juce::Component {
    * @param min minimum value
    * @param max maximum value
    */
-  void yLim(const float min, const float max);
+  void setYLim(const float min, const float max);
 
   /**
    * @brief Set the Z-limits
@@ -122,7 +122,7 @@ class Plot3D : public juce::Component {
    * @param min minimum value
    * @param max maximum value
    */
-  void zLim(const float min, const float max);
+  void setZLim(const float min, const float max);
 
   /** @brief Set the text on the x-axis. */
   void setXLabel(const std::string &x_label);

--- a/include/include/cmp_plot3d.h
+++ b/include/include/cmp_plot3d.h
@@ -59,7 +59,7 @@ struct Series3DData {
  */
 class Plot3D : public juce::Component {
  public:
-  /** Destructor, making sure to set the lookandfeel in all subcomponenets to
+  /** Destructor, making sure to set the lookandfeel in all subcomponents to
    * nullptr. */
   ~Plot3D() override;
 

--- a/source/cmp_lookandfeel.cpp
+++ b/source/cmp_lookandfeel.cpp
@@ -42,7 +42,7 @@ void PlotLookAndFeel::setDefaultPlotColours() noexcept {
   setColour(Plot::zoom_frame_colour, juce::Colour(0xff99A3A4));
 
   setColour(Plot::grid_colour, juce::Colour(0x7F99A3A4));
-  setColour(Plot::transluent_grid_colour, juce::Colour(0x4099A3A4));
+  setColour(Plot::translucent_grid_colour, juce::Colour(0x4099A3A4));
 
   setColour(Plot::x_grid_label_colour, juce::Colour(0xffaab7b8));
   setColour(Plot::y_grid_label_colour, juce::Colour(0xffaab7b8));
@@ -421,7 +421,7 @@ void PlotLookAndFeel::drawGridLine(juce::Graphics& g, const GridLine& grid_line,
   const auto x_and_len = grid_line.length + grid_line.position.getX();
 
   if (grid_line.type == GridLine::Type::translucent)
-    g.setColour(findColour(Plot::transluent_grid_colour));
+    g.setColour(findColour(Plot::translucent_grid_colour));
   else if (grid_line.type == GridLine::Type::normal)
     g.setColour(findColour(Plot::grid_colour));
 

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -200,7 +200,7 @@ void Plot::updateXLim(const Lim_f& new_x_lim) {
   UNLIKELY if (m_x_scaling.getValue() == Scaling::logarithmic &&
                new_x_lim.isMinOrMaxZero()) {
     throw std::invalid_argument(
-        "The min/max x-value is zero or 'xLim' has been called with a zero "
+        "The min/max x-value is zero or 'setXLim' has been called with a zero "
         "value. 10log(0) = -inf");
   }
 
@@ -221,7 +221,7 @@ void Plot::updateYLim(const Lim_f& new_y_lim) {
   UNLIKELY if (m_y_scaling.getValue() == Scaling::logarithmic &&
                new_y_lim.isMinOrMaxZero()) {
     throw std::invalid_argument(
-        "The min/max y-value is zero or 'yLim' has been called with a zero "
+        "The min/max y-value is zero or 'setYLim' has been called with a zero "
         "value. 10log(0) = -inf");
   }
 
@@ -265,13 +265,13 @@ void Plot::setAutoYScale() {
   updateYLim(m_y_lim_start);
 }
 
-void Plot::xLim(const float min, const float max) {
+void Plot::setXLim(const float min, const float max) {
   updateXLim({min, max});
   m_x_lim_start = {min, max};
   m_x_autoscale = false;
 }
 
-void Plot::yLim(const float min, const float max) {
+void Plot::setYLim(const float min, const float max) {
   updateYLim({min, max});
   m_y_lim_start = {min, max};
   m_y_autoscale = false;

--- a/source/cmp_plot3d.cpp
+++ b/source/cmp_plot3d.cpp
@@ -71,7 +71,7 @@ Plot3D::Plot3D(const Scaling x_scaling, const Scaling y_scaling,
   resetLookAndFeelChildrens(&getLookAndFeel());
 }
 
-void Plot3D::xLim(const float min, const float max) {
+void Plot3D::setXLim(const float min, const float max) {
   if (min >= max)
     throw std::invalid_argument("Min value must be lower than max value.");
 
@@ -81,7 +81,7 @@ void Plot3D::xLim(const float min, const float max) {
   updateChildrenParameters();
 }
 
-void Plot3D::yLim(const float min, const float max) {
+void Plot3D::setYLim(const float min, const float max) {
   if (min >= max)
     throw std::invalid_argument("Min value must be lower than max value.");
 
@@ -91,7 +91,7 @@ void Plot3D::yLim(const float min, const float max) {
   updateChildrenParameters();
 }
 
-void Plot3D::zLim(const float min, const float max) {
+void Plot3D::setZLim(const float min, const float max) {
   if (min >= max)
     throw std::invalid_argument("Min value must be lower than max value.");
 

--- a/tests/gui/utils/test_macros.h
+++ b/tests/gui/utils/test_macros.h
@@ -52,9 +52,9 @@
 #define FILL_BETWEEN_C(INDICES, COLOUR) \
   { GET_PLOT->fillBetween(INDICES, COLOUR); }
 
-#define X_LIM(MIN, MAX) GET_PLOT->xLim(MIN, MAX);
+#define X_LIM(MIN, MAX) GET_PLOT->setXLim(MIN, MAX);
 
-#define Y_LIM(MIN, MAX) GET_PLOT->yLim(MIN, MAX);
+#define Y_LIM(MIN, MAX) GET_PLOT->setYLim(MIN, MAX);
 
 #define GRID_ON GET_PLOT->setGridType(cmp::GridType::grid);
 

--- a/tests/unit_tests/cmp_pixel_points_test.cpp
+++ b/tests/unit_tests/cmp_pixel_points_test.cpp
@@ -128,8 +128,8 @@ SECTION(PixelPointsPipelineTest, "Pixel points pipeline") {
     cmp::Plot plot;
     plot.setBounds(0, 0, 500, 400);
     plot.plot({{.x = x_data, .y = y_data}});
-    plot.xLim(x_lim.min, x_lim.max);
-    plot.yLim(y_lim.min, y_lim.max);
+    plot.setXLim(x_lim.min, x_lim.max);
+    plot.setYLim(y_lim.min, y_lim.max);
 
     const auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 1ul);

--- a/tests/unit_tests/cmp_plot3d_test.cpp
+++ b/tests/unit_tests/cmp_plot3d_test.cpp
@@ -130,14 +130,14 @@ SECTION(Plot3DClass, "Plot3D class") {
     cmp::Plot3D plot_tmp;
     plot_tmp.setBounds(0, 0, 600, 500);
     plot_tmp.setView(0.f, 90.f);
-    plot_tmp.xLim(0.f, 20.f);
+    plot_tmp.setXLim(0.f, 20.f);
     plot_tmp.plot3({{.x = x_data1, .y = y_data1, .z = z_data1}});
 
     const auto series = getChildComponentHelper<cmp::Series3D>(plot_tmp);
     const auto& pixel_points = series[0]->getPixelPoints();
     const auto axes_bounds = series[0]->getLocalBounds().toFloat();
 
-    // x data 0..10 with xLim 0..20 only reaches the middle of the series
+    // x data 0..10 with setXLim 0..20 only reaches the middle of the series
     // area; the auto-scaled y still spans the full height.
     expectWithinAbsoluteError(pixel_points[2].getX(),
                               axes_bounds.getWidth() / 2.f, 1e-2f);
@@ -149,7 +149,7 @@ SECTION(Plot3DClass, "Plot3D class") {
     auto exception_thrown = false;
 
     try {
-      plot_tmp.zLim(1.f, 1.f);
+      plot_tmp.setZLim(1.f, 1.f);
     } catch (const std::invalid_argument&) {
       exception_thrown = true;
     }

--- a/tests/unit_tests/cmp_trace_test.cpp
+++ b/tests/unit_tests/cmp_trace_test.cpp
@@ -17,8 +17,8 @@ SECTION(TraceClass, "Trace class") {
   const std::vector<float> y_data = {1.f, 2.f, 3.f, 4.f};
   cmp::Plot plot;
   plot.setBounds(0, 0, 100, 100);
-  plot.xLim(1.f, 4.f);
-  plot.yLim(1.f, 4.f);
+  plot.setXLim(1.f, 4.f);
+  plot.setYLim(1.f, 4.f);
 
   TEST("Empty trace points") {
     auto trace_points = getChildComponentHelper<TracePoint_f>(plot);
@@ -122,8 +122,8 @@ SECTION(MoveSelectedTracePointsTest, "Move selected trace points") {
     plot.setVisible(true);
     plot.setMovePointsType(cmp::PixelPointMoveType::horizontal_vertical);
     plot.plot({{.x = x_data, .y = y_data}});
-    plot.xLim(x_lim.min, x_lim.max);
-    plot.yLim(y_lim.min, y_lim.max);
+    plot.setXLim(x_lim.min, x_lim.max);
+    plot.setYLim(y_lim.min, y_lim.max);
 
     // Create a tracepoint on the data point (10, 2) (data index 1).
     plot.setTracePoint({10.f, 2.f});


### PR DESCRIPTION
## Public API cleanup: docs, English, and naming standard

Two commits:

### 1. Non-breaking doc pass (`78de118`)
Comment/Doxygen-only changes across the public headers:
- **Doxygen correctness:** trailing enum member docs now use `/**<` so they attach to the member they *follow* (a plain `/**` was documenting the *next* member).
- Dropped redundant `@return void.` lines.
- Spelling/grammar: `subcomponenets`, `componenet`, `poiter`, `postions`, `typ`, `transulent`, `alot`, `shares`, `a interface`, `where you wanted`, etc.
- British **colour** in prose to match the identifiers (`series_colour`, `juce::Colour`).
- Stale references fixed: `realTimePlot()` → `plotUpdateYOnly()`, `cmp:datamodels.h` → `cmp_datamodels.h`, and the `LookAndFeelMethods` pointer to the real default impl.
- Documented the `Plot` constructor (was a malformed `/* Constructor **/`).

### 2. Naming standard (`f9dc278`) — ⚠️ breaking
- **`xLim`/`yLim` → `setXLim`/`setYLim`** and **`Plot3D::zLim` → `setZLim`** — they were the only setters without the `set*` prefix used everywhere else (`setXLabel`, `setTitle`, `setYTicks`…).
- **`ColourIds::transluent_grid_colour` → `translucent_grid_colour`** — typo in a public colour id.

All call sites (examples, tests, extras) updated; changelog updated under Breaking Changes.

**Verified:** full build clean, all 118 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
