### PR TITLE
Plot: single-series plotUpdateYOnly overload; modernize realtime example

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 - `Plot3D`: 3D line plotting with per-axis linear/logarithmic scaling.
 - `clear()` (and `Plot3D::clear()`): remove all series. Plotting an empty
   list does the same.
+- `plotUpdateYOnly(std::vector<float>)`: single-series overload for the common
+  real-time case, matching the single-series `plot({.y = ...})`.
 - Renamed realTimePlot to plotUpdateYOnly.
 - Gradient below series using SeriesAttribute
 

--- a/examples/example_apps/realtime/realtime.h
+++ b/examples/example_apps/realtime/realtime.h
@@ -23,7 +23,7 @@ class realtime : public juce::Component, private juce::Timer {
 
     startTimerHz(30);
 
-    // Always plot atleast ones before calling realTimePlot
+    // Always plot at least once before calling plotUpdateYOnly.
     m_plot.plot({.y = cmp::generateSineWaveVector<float>((1 << 10), -1.0f, 1.0f,
                                                          1, 1)});
   };
@@ -37,9 +37,10 @@ class realtime : public juce::Component, private juce::Timer {
       return juce::MathConstants<float>::pi * 0.01f;
     };
 
-    // Plot some values.
-    m_plot.plotUpdateYOnly({cmp::generateSineWaveVector<float>(
-        (1 << 10), -1.0f, 1.0f, periods, phase)});
+    // Update only the y-values of the single series (no extra braces).
+    m_plot.plotUpdateYOnly(
+        cmp::generateSineWaveVector<float>((1 << 10), -1.0f, 1.0f, periods,
+                                           phase));
 
     if (periods >= 75.f) {
       f_period = []() { return -1.0f; };

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -133,6 +133,16 @@ class Plot : public juce::Component {
    */
   void plotUpdateYOnly(const std::vector<std::vector<float>> &y_data);
 
+  /** @brief Update only the y-data of a single series.
+   *
+   * Convenience overload for the common real-time case of one series, so the
+   * y-values need not be wrapped in an extra pair of braces:
+   * @code plotUpdateYOnly(samples); @endcode
+   *
+   * @param y_data the new y-values for the first series.
+   */
+  void plotUpdateYOnly(std::vector<float> y_data);
+
   /** @brief Fill the area between two data lines
    *
    * Steps to use:

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -414,6 +414,12 @@ void Plot::plotUpdateYOnly(const std::vector<std::vector<float>>& y_data) {
   repaint(m_axes_bounds);
 }
 
+void Plot::plotUpdateYOnly(std::vector<float> y_data) {
+  std::vector<std::vector<float>> data;
+  data.push_back(std::move(y_data));
+  plotUpdateYOnly(data);
+}
+
 void Plot::fillBetween(const std::vector<SpreadIndex>& spread_indices,
                        const std::vector<juce::Colour>& fill_area_colours) {
   m_spread_list.resize(spread_indices.size());

--- a/tests/gui/realtime/rt_tests.cpp
+++ b/tests/gui/realtime/rt_tests.cpp
@@ -62,7 +62,7 @@ TEST(real_time_plot_function, real_time) {
       y = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     }
 
-    GET_PLOT->plotUpdateYOnly({y_test_data});
+    GET_PLOT->plotUpdateYOnly(y_test_data);
   };
 }
 

--- a/tests/unit_tests/cmp_trace_test.cpp
+++ b/tests/unit_tests/cmp_trace_test.cpp
@@ -62,7 +62,7 @@ SECTION(TraceClass, "Trace class") {
   }
 
   TEST("Update existing plot Y only") {
-    plot.plotUpdateYOnly({{4.f, 3.f, 2.f, 1.f}});
+    plot.plotUpdateYOnly({4.f, 3.f, 2.f, 1.f});
     auto trace_points = getChildComponentHelper<TracePoint_f>(plot);
     expect(!trace_points.empty());
     expectEquals(trace_points.size(), 2ul);


### PR DESCRIPTION
The realtime example already used `plot({.y = ...})`, but its per-frame update still used the braced-matrix `plotUpdateYOnly({...})` and its comment referenced the old `realTimePlot` name.

- Add `plotUpdateYOnly(std::vector<float>)` so the common single-series real-time case needs no extra braces, matching `plot({.y = ...})`.
- Update the realtime example to use it; fix the stale `realTimePlot` comment.
- Two braced single-series test calls adjusted (they'd otherwise be ambiguous between the new overload and the matrix one).

Full build clean; all 118 unit tests pass.