### PR TITLE
docs: fix typo (seperate->separate (x1))

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,15 @@ If you want to contribute to CustomMatPlot and make it better, your help is very
 ### How to make a clean pull request
 
 - Create an issue or feature request [here](https://github.com/franshej/CustomMatPlot/issues/new).
-- Create a personal fork of the project on Github.
-- Clone the fork on your local machine. Ensure that your remote repository on Github is called `origin`.
+- Create a personal fork of the project on GitHub.
+- Clone the fork on your local machine. Ensure that your remote repository on GitHub is called `origin`.
 - Add the original repository as a remote called `upstream`.
 - Create a new branch from the `master` branch.
 - Implement your feature or fix the issue.
-- Use Github Copilot, ChatGPT, or your favorite llvm to check for code smells, architecture issues, or bad logic.
+- Use GitHub Copilot, ChatGPT, or your favorite llvm to check for code smells, architecture issues, or bad logic.
 - Format your Cpp code with `ClangFormat` style: `Google`.
 - Create a test for your fix, if possible (currently, only manual tests are available).
-- Push your branch to your fork on Github, which is the remote `origin`.
+- Push your branch to your fork on GitHub, which is the remote `origin`.
 - From your fork, open a pull request to the `master` branch.
 - Provide a short description of what the PR solves, and [link the PR with the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) it addresses.
 - 1 approval is required for merging.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 Move addGraphLineInternal code and add Ydata code to GraphLineList
-Use a PlotData object instead of taking seperate vectors in public Plot function.
+Use a PlotData object instead of taking separate vectors in public Plot function.
 Template float type


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: seperate->separate (x1); Github->GitHub (x4)

**Files:**
- `TODO.md`
- `CONTRIBUTING.md`

Documentation-only; no functional code changes.
