### PR TITLE
Trace: Explicitly instantiate TracePoint<float> to fix the test link

### DIFF
--- a/source/cmp_trace.cpp
+++ b/source/cmp_trace.cpp
@@ -479,6 +479,7 @@ bool TraceLabelPoint<ValueType>::isSelected() const {
   return selected;
 }
 
+template struct TracePoint<float>;
 template struct TraceLabelPoint<float>;
 
 template <class ValueType>


### PR DESCRIPTION
`TracePoint<float>` was never explicitly instantiated - only
`TraceLabelPoint<float>` was - so no definition of
`TracePoint<float>::getDataPoint` was emitted.

`cmp_trace_test.cpp` calls it, so `cmp_plot_test` failed to link:

```
ld: Undefined symbols:
  cmp::TracePoint<float>::getDataPoint() const, referenced from:
      TraceClass::runTest() in cmp_trace_test.cpp.o
```

That took down the whole unit test suite, not just the trace tests. With the
instantiation added, `cmp_plot_test` links and all 124 test sections pass.
