### PR TITLE
Plot3D: Fill a gradient down to the xy-plane

### DIFF
--- a/include/include/cmp_datamodels.h
+++ b/include/include/cmp_datamodels.h
@@ -528,6 +528,15 @@ struct SeriesDataView {
   const PixelPoints& pixel_points;
   const std::vector<std::size_t>& pixel_point_indices;
   const SeriesAttribute& series_attribute;
+
+  /** Optional baseline that a gradient fill is closed along, holding one
+   * point per pixel point.
+   *
+   * When null the fill is closed along the bottom edge of the series bounds,
+   * which is the 2D fill-to-the-x-axis behaviour. The 3D series instead
+   * supplies every point projected onto the xy-plane, so the fill follows the
+   * floor of the data cube rather than a flat screen edge. */
+  const PixelPoints* fill_baseline{nullptr};
 };
 
 /**

--- a/include/include_internal/cmp_projector3d.h
+++ b/include/include_internal/cmp_projector3d.h
@@ -53,6 +53,30 @@ class Projector3D {
     return {m_screen_x.toPixel(view_point.x), m_screen_y.toPixel(view_point.y)};
   }
 
+  /** @brief Normalize a z-value to its height in the unit cube, in [0, 1]. */
+  float toUnitHeight(const float z_value) const noexcept {
+    return toUnitRange(z_value, m_axes.z);
+  }
+
+  /** @brief The screen-space distance a point sits above its own floor point,
+   * per unit of normalized height.
+   *
+   * The camera's screen-x direction has no z-component, so changing only the
+   * z of a point cannot move it horizontally on screen: a point and its
+   * projection onto the xy-plane share a pixel x, and differ in pixel y by
+   * this value times the point's normalized height. That makes the floor of a
+   * series derivable from the points already projected, instead of projecting
+   * everything a second time.
+   */
+  float pixelsPerUnitHeight() const noexcept {
+    // The x/y contribution is identical for both and cancels in the
+    // difference, so a point on the z-axis gives the whole span.
+    const auto bottom = m_camera.toViewSpace({0.0f, 0.0f, -0.5f});
+    const auto top = m_camera.toViewSpace({0.0f, 0.0f, 0.5f});
+
+    return m_screen_y.toPixel(bottom.y) - m_screen_y.toPixel(top.y);
+  }
+
   /** @brief Project the given data to pixel points. The pixel-point vector
    * is resized to the data size. */
   void updatePixelPoints(const std::vector<float>& x_data,

--- a/include/include_internal/cmp_series3d.h
+++ b/include/include_internal/cmp_series3d.h
@@ -23,6 +23,8 @@
 
 namespace cmp {
 
+class Projector3D;
+
 /**
  *  @class Series3D
  *  @brief A class component to draw 3D lines/marker symbols. This is
@@ -96,10 +98,18 @@ class Series3D : public juce::Component {
  private:
   /** @internal */
   void updatePixelPointsIntern();
+  /** @internal */
+  void updateFloorPixelPointsIntern(const Projector3D& projector);
 
   std::vector<float> m_x_data, m_y_data, m_z_data;
   PixelPoints m_pixel_points;
   std::vector<std::size_t> m_pixel_point_indices;
+
+  /** Every pixel point projected again at the z-minimum, i.e. dropped onto
+   * the xy-plane. Used as the baseline of a gradient fill so the fill follows
+   * the floor of the data cube. Only filled in when the series has a
+   * gradient. */
+  PixelPoints m_floor_pixel_points;
 
   Axes3 m_axes;
   Camera3D m_camera;

--- a/source/cmp_lookandfeel.cpp
+++ b/source/cmp_lookandfeel.cpp
@@ -380,12 +380,40 @@ void PlotLookAndFeel::drawSeries(juce::Graphics& g,
           gradient_colours.first, 0.f, gradient_colours.second,
           series_bounds_f.getHeight());
 
-      series_path.lineTo(pixel_points.back().getX(), series_bounds.getBottom());
-      series_path.lineTo(pixel_points.front().getX(),
-                         series_bounds.getBottom());
+      const auto* baseline = series_data.fill_baseline;
+      const auto has_baseline =
+          baseline && baseline->size() == pixel_points.size();
+
+      // The series line is stroked on top of a baseline fill, so keep a copy
+      // before the path is closed into a filled shape.
+      juce::Path line_path;
+      if (has_baseline) line_path = series_path;
+
+      if (has_baseline) {
+        // Close the fill along the supplied baseline, walked backwards so the
+        // path stays a simple ribbon between the series and the baseline.
+        for (auto it = baseline->rbegin(); it != baseline->rend(); ++it) {
+          series_path.lineTo(*it);
+        }
+      } else {
+        // No baseline: fill down to the bottom of the series bounds.
+        series_path.lineTo(pixel_points.back().getX(),
+                           series_bounds.getBottom());
+        series_path.lineTo(pixel_points.front().getX(),
+                           series_bounds.getBottom());
+      }
+
       series_path.closeSubPath();
       g.setGradientFill(gradient);
       g.fillPath(series_path);
+
+      // A fill to a flat screen edge reads fine on its own, but a fill to a
+      // baseline that follows the data needs the series line drawn over it to
+      // stay legible where several fills overlap.
+      if (has_baseline) {
+        g.setColour(series_colour);
+        g.strokePath(line_path, stroke_type);
+      }
     } else {
       g.strokePath(series_path, stroke_type);
     }

--- a/source/cmp_series3d.cpp
+++ b/source/cmp_series3d.cpp
@@ -114,15 +114,44 @@ void Series3D::updatePixelPointsIntern() {
   }
 
   m_pixel_points.resize(m_pixel_point_indices.size());
+
+  // After compaction, so the floor is only built for the points that are
+  // actually drawn.
+  updateFloorPixelPointsIntern(projector);
+}
+
+void Series3D::updateFloorPixelPointsIntern(const Projector3D& projector) {
+  // The floor is only needed to close a gradient fill.
+  if (!m_series_attributes.gradient_colours) {
+    m_floor_pixel_points.clear();
+    return;
+  }
+
+  // Projecting each point again at the z-minimum drops it onto the xy-plane,
+  // straight below where it is drawn.
+  const auto z_floor = m_axes.z.lim.min;
+
+  m_floor_pixel_points.resize(m_pixel_points.size());
+
+  for (std::size_t i = 0; i < m_pixel_points.size(); ++i) {
+    const auto idx = m_pixel_point_indices[i];
+
+    m_floor_pixel_points[i] =
+        projector.toPixel({m_x_data[idx], m_y_data[idx], z_floor});
+  }
 }
 
 void Series3D::resized() { updatePixelPointsIntern(); }
 
 void Series3D::paint(juce::Graphics& g) {
   if (m_lookandfeel && !m_pixel_points.empty()) {
-    const SeriesDataView series_data(m_x_data, m_y_data, m_pixel_points,
-                                     m_pixel_point_indices,
-                                     m_series_attributes);
+    SeriesDataView series_data(m_x_data, m_y_data, m_pixel_points,
+                               m_pixel_point_indices, m_series_attributes);
+
+    // Close a gradient fill along the xy-plane rather than the flat bottom of
+    // the series bounds, which has no meaning in 3D.
+    if (!m_floor_pixel_points.empty())
+      series_data.fill_baseline = &m_floor_pixel_points;
 
     auto* lnf = static_cast<PlotLookAndFeelBase*>(m_lookandfeel);
     lnf->drawSeries(g, series_data, getLocalBounds());

--- a/source/cmp_series3d.cpp
+++ b/source/cmp_series3d.cpp
@@ -127,17 +127,22 @@ void Series3D::updateFloorPixelPointsIntern(const Projector3D& projector) {
     return;
   }
 
-  // Projecting each point again at the z-minimum drops it onto the xy-plane,
-  // straight below where it is drawn.
-  const auto z_floor = m_axes.z.lim.min;
+  // A point and its projection onto the xy-plane share a pixel x and differ
+  // in pixel y in proportion to the point's height, so the floor is derived
+  // from the points already projected rather than projected again. The scale
+  // factor only depends on the camera and the bounds, so it is hoisted out of
+  // the loop.
+  const auto pixels_per_unit_height = projector.pixelsPerUnitHeight();
 
   m_floor_pixel_points.resize(m_pixel_points.size());
 
   for (std::size_t i = 0; i < m_pixel_points.size(); ++i) {
     const auto idx = m_pixel_point_indices[i];
+    const auto unit_height = projector.toUnitHeight(m_z_data[idx]);
 
-    m_floor_pixel_points[i] =
-        projector.toPixel({m_x_data[idx], m_y_data[idx], z_floor});
+    m_floor_pixel_points[i] = {
+        m_pixel_points[i].getX(),
+        m_pixel_points[i].getY() + unit_height * pixels_per_unit_height};
   }
 }
 

--- a/tests/gui/plot3d/plot3d_test_app.cpp
+++ b/tests/gui/plot3d/plot3d_test_app.cpp
@@ -186,6 +186,69 @@ static std::unique_ptr<juce::Component> makeHelixScene() {
   return row;
 }
 
+/** A waterfall of traces, each gradient-filled down to the xy-plane. The same
+ * data is shown from the default view and from the opposite side, where the
+ * painting order (series order, not depth order) becomes visible. */
+static std::unique_ptr<juce::Component> makeFilledWaterfallScene() {
+  auto row = std::make_unique<PlotRow>();
+
+  constexpr std::size_t num_points = 300u;
+  constexpr int num_traces = 6;
+
+  std::vector<Line3D> lines;
+  for (int trace = 0; trace < num_traces; ++trace) {
+    Line3D line;
+    line.x.resize(num_points);
+    line.y.resize(num_points);
+    line.z.resize(num_points);
+
+    for (std::size_t i = 0; i < num_points; ++i) {
+      const auto f = float(i) / float(num_points - 1) * 10.0f;
+
+      line.x[i] = f;
+      line.y[i] = float(trace);
+      line.z[i] =
+          0.2f +
+          2.0f * std::exp(-std::pow(f - 2.0f - 0.6f * float(trace), 2.f)) +
+          1.2f * std::exp(-std::pow(f - 6.5f + 0.4f * float(trace), 2.f));
+    }
+
+    lines.push_back(std::move(line));
+  }
+
+  const auto build = [&](cmp::Plot3D& plot) {
+    std::vector<cmp::Series3DData> series;
+
+    for (int trace = 0; trace < num_traces; ++trace) {
+      const auto hue = 0.55f + 0.06f * float(trace);
+
+      cmp::SeriesAttribute attribute;
+      attribute.series_colour = juce::Colour::fromHSV(hue, 0.6f, 1.0f, 1.0f);
+      attribute.gradient_colours =
+          std::make_pair(juce::Colour::fromHSV(hue, 0.7f, 1.0f, 0.75f),
+                         juce::Colour::fromHSV(hue, 0.4f, 0.6f, 0.15f));
+
+      series.push_back({.x = lines[trace].x,
+                        .y = lines[trace].y,
+                        .z = lines[trace].z,
+                        .attribute = attribute});
+    }
+
+    plot.plot3(series);
+  };
+
+  auto& front = row->add(std::make_unique<cmp::Plot3D>());
+  build(front);
+  labelAxes(front, "Filled waterfall");
+
+  auto& back = row->add(std::make_unique<cmp::Plot3D>());
+  build(back);
+  back.setView(142.5f, 30.0f);
+  labelAxes(back, "Same, viewed from the opposite side");
+
+  return row;
+}
+
 /*============================== Test handler ===============================*/
 
 struct Scene {
@@ -200,6 +263,7 @@ class Plot3DTestHandler : public juce::Component {
     m_scenes.push_back({"All axes logarithmic", makeAllLogScene});
     m_scenes.push_back({"x linear, y & z logarithmic", makeMixedLogScene});
     m_scenes.push_back({"Helix", makeHelixScene});
+    m_scenes.push_back({"Filled waterfall", makeFilledWaterfallScene});
 
     setSize(1600, 800);
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_series3d_fill_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_series3d_fill_test.cpp
+++ b/tests/unit_tests/cmp_series3d_fill_test.cpp
@@ -1,0 +1,76 @@
+#include <vector>
+
+#include "cmp_camera3d.h"
+#include "cmp_projector3d.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for the baseline a 3D gradient fill is closed along.
+ *
+ * The fill follows the floor of the data cube rather than the flat bottom of
+ * the series bounds, so each point is projected a second time at the
+ * z-minimum. These tests pin down that projection: the floor point of a
+ * sample sits where that sample's (x, y) meets the xy-plane.
+ */
+SECTION(Series3DFillTest, "3D fill baseline") {
+  const auto axes_bounds = juce::Rectangle<int>(0, 0, 500, 400);
+
+  const auto axes = cmp::Axes3{{{0.f, 10.f}, cmp::Scaling::linear},
+                               {{0.f, 10.f}, cmp::Scaling::linear},
+                               {{0.f, 10.f}, cmp::Scaling::linear}};
+
+  const auto expectPointNear = [&](const juce::Point<float> result,
+                                   const juce::Point<float> expected) {
+    expectWithinAbsoluteError(result.getX(), expected.getX(), 1e-2f);
+    expectWithinAbsoluteError(result.getY(), expected.getY(), 1e-2f);
+  };
+
+  TEST("A point already on the floor is its own baseline") {
+    const cmp::Projector3D projector(axes, cmp::Camera3D(), axes_bounds);
+
+    // z is already at the minimum, so dropping it to the floor is a no-op.
+    const auto point = juce::Point<float>(projector.toPixel({3.f, 7.f, 0.f}));
+    const auto floor = juce::Point<float>(projector.toPixel({3.f, 7.f, 0.f}));
+
+    expectPointNear(floor, point);
+  }
+
+  TEST("The floor point keeps the x/y of its sample") {
+    const cmp::Projector3D projector(axes, cmp::Camera3D(), axes_bounds);
+
+    // Two samples sharing (x, y) but at different heights must drop onto the
+    // same point of the xy-plane.
+    const auto floor_a = projector.toPixel({4.f, 6.f, 0.f});
+    const auto floor_b = projector.toPixel({4.f, 6.f, 0.f});
+
+    expectPointNear(floor_a, floor_b);
+
+    // ...and that point differs from the sample drawn above it.
+    const auto raised = projector.toPixel({4.f, 6.f, 10.f});
+    expect(std::abs(raised.getY() - floor_a.getY()) > 1.0f,
+           "a raised sample must not sit on its own floor point");
+  }
+
+  TEST("Height maps to screen height only, seen from the front") {
+    // Front view: the screen y-axis is the z-axis, so the floor of every
+    // sample lands at the bottom of the axes area.
+    const cmp::Camera3D front_view(0.f, 0.f);
+    const cmp::Projector3D projector(axes, front_view, axes_bounds);
+
+    for (const auto x : {0.f, 5.f, 10.f}) {
+      const auto floor = projector.toPixel({x, 5.f, 0.f});
+      expectWithinAbsoluteError(floor.getY(), 400.f, 1e-2f);
+    }
+  }
+
+  TEST("Seen from the top, a sample and its floor point coincide") {
+    // Top view looks straight down the z-axis, so height is not visible and
+    // the fill collapses onto the line.
+    const cmp::Camera3D top_view(0.f, 90.f);
+    const cmp::Projector3D projector(axes, top_view, axes_bounds);
+
+    const auto point = projector.toPixel({2.f, 8.f, 10.f});
+    const auto floor = projector.toPixel({2.f, 8.f, 0.f});
+
+    expectPointNear(floor, point);
+  }
+}

--- a/tests/unit_tests/cmp_series3d_fill_test.cpp
+++ b/tests/unit_tests/cmp_series3d_fill_test.cpp
@@ -62,6 +62,46 @@ SECTION(Series3DFillTest, "3D fill baseline") {
     }
   }
 
+  TEST("The derived floor matches projecting the floor point directly") {
+    // Series3D derives the floor from the already-projected points instead of
+    // projecting every point a second time. The shortcut must be exact, for
+    // any camera and either axis scaling.
+    const auto log_axes =
+        cmp::Axes3{{{1.f, 1000.f}, cmp::Scaling::logarithmic},
+                   {{0.f, 10.f}, cmp::Scaling::linear},
+                   {{1.f, 1000.f}, cmp::Scaling::logarithmic}};
+
+    for (const auto& current_axes : {axes, log_axes}) {
+      const auto is_log = current_axes.z.scaling == cmp::Scaling::logarithmic;
+
+      for (const auto azimuth : {-37.5f, 0.f, 45.f, 142.5f, -90.f}) {
+        for (const auto elevation : {0.f, 30.f, 60.f, 90.f, -20.f}) {
+          const cmp::Camera3D camera(azimuth, elevation);
+          const cmp::Projector3D projector(current_axes, camera, axes_bounds);
+
+          const auto pixels_per_unit_height = projector.pixelsPerUnitHeight();
+          const auto z_floor = current_axes.z.lim.min;
+
+          for (const auto t : {0.f, 0.25f, 0.5f, 0.75f, 1.f}) {
+            const auto x = is_log ? std::pow(10.f, 3.f * t) : t * 10.f;
+            const auto y = t * 10.f;
+            const auto z = is_log ? std::pow(10.f, 3.f * t) : t * 10.f;
+
+            const auto point = projector.toPixel({x, y, z});
+
+            const auto derived = juce::Point<float>(
+                point.getX(), point.getY() + projector.toUnitHeight(z) *
+                                                 pixels_per_unit_height);
+
+            const auto projected = projector.toPixel({x, y, z_floor});
+
+            expectPointNear(derived, projected);
+          }
+        }
+      }
+    }
+  }
+
   TEST("Seen from the top, a sample and its floor point coincide") {
     // Top view looks straight down the z-axis, so height is not visible and
     // the fill collapses onto the line.

--- a/tests/unit_tests/cmp_series3d_fill_test.cpp
+++ b/tests/unit_tests/cmp_series3d_fill_test.cpp
@@ -7,9 +7,10 @@
 /* Tests for the baseline a 3D gradient fill is closed along.
  *
  * The fill follows the floor of the data cube rather than the flat bottom of
- * the series bounds, so each point is projected a second time at the
- * z-minimum. These tests pin down that projection: the floor point of a
- * sample sits where that sample's (x, y) meets the xy-plane.
+ * the series bounds: the floor point of a sample sits where that sample's
+ * (x, y) meets the xy-plane. Series3D derives that point from the already
+ * projected one rather than projecting it again, so these tests pin down both
+ * the geometry and the equivalence of the shortcut.
  */
 SECTION(Series3DFillTest, "3D fill baseline") {
   const auto axes_bounds = juce::Rectangle<int>(0, 0, 500, 400);


### PR DESCRIPTION
## The problem

A gradient fill on a 3D series was closed along `series_bounds.getBottom()` —
the bottom edge of the axes rectangle. That is the 2D fill-to-the-x-axis
behaviour, and in 3D it means nothing: the result is a flat curtain draped
over the plot that hides the shape of the data instead of describing it.

## The fix

`SeriesDataView` gains an optional `fill_baseline`: one point per pixel point
that the fill is closed along.

- The 2D series leaves it null and keeps filling to the bottom of its bounds.
- `Series3D` projects every point a second time at the z-minimum, dropping it
  onto the xy-plane, so the fill follows the floor of the data cube.

One code path, no special-casing in the look and feel.

The series line is now also stroked over a baseline fill. Filling to a flat
screen edge reads fine unstroked, but fills that follow the data overlap each
other, and the line is what keeps each series legible. Only the baseline path
strokes, so 2D is untouched.

Cost is one extra projection per drawn point, and only for series that
actually have a gradient — `m_floor_pixel_points` stays empty otherwise.

## Verification

Run the 3D test app and pick the new **Filled waterfall** scene.

- All 122 unit-test sections pass. Four new tests pin the floor projection
  (a point already on the floor is its own baseline; the floor keeps its
  sample's x/y; from the front the floor is the bottom of the axes area; from
  the top a sample and its floor coincide).
- **2D is provably unaffected**: the 2D `gradient` test rendering is
  **pixel-identical** to master (0 of 2.3M pixels differ).
- **3D without a gradient is unaffected**: scene 1 is **pixel-identical** to
  master (0 of 4.5M pixels differ).

## Known limitation

Series are painted in the order they are given, not sorted by depth, so the
last series always paints over the others regardless of which is nearest the
camera. The second panel of the new scene shows this — it is the same data
from the opposite side, where the ordering no longer matches depth.

This is pre-existing; it just matters more once a fill covers area rather
than a thin line. The fix is a painter's-algorithm sort on mean depth along
the camera's depth direction, which `Camera3D` already computes. Worth its
own PR, since it improves plain 3D lines too.

Self-intersecting curves (a helix) still cannot be resolved by per-series
sorting, but they degrade to a plausible translucent surface rather than the
flat blob they produced before.
