### PR TITLE
Plot: Fix out-of-bounds read when plotUpdateYOnly changes the size

### DIFF
--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -129,6 +129,12 @@ class Plot : public juce::Component {
    * function. x-data must be set through the 'plot' function before calling
    * this function.
    *
+   * Pass the same number of y-values as the series already holds. Passing a
+   * different number is handled - the x-data is regenerated as a ramp, which
+   * replaces any x-data set through 'plot' - but it costs exactly the work
+   * this function exists to avoid, so prefer 'plot' when the number of points
+   * changes.
+   *
    * @param y_data vector of vectors with the y-values.
    */
   void plotUpdateYOnly(const std::vector<std::vector<float>> &y_data);
@@ -315,7 +321,7 @@ class Plot : public juce::Component {
   enum ColourIds : int {
     background_colour,        /**< Colour of the background. */
     grid_colour,              /**< Colour of the grids. */
-    translucent_grid_colour,   /**< Colour of the translucent grids. */
+    translucent_grid_colour,  /**< Colour of the translucent grids. */
     x_grid_label_colour,      /**< Colour of the label for each x-grid line. */
     y_grid_label_colour,      /**< Colour of the label for each y-grid line. */
     frame_colour,             /**< Colour of the frame around the axes area. */
@@ -498,6 +504,13 @@ class Plot : public juce::Component {
    * copy each); shared by the plot(SeriesData) and plot(SeriesDataList)
    * overloads. */
   void plotSeries(std::span<const SeriesData> series);
+  /** @internal Whether every series of this type already holds exactly as
+   * many x-values as the matching entry of 'y_data' has y-values. Must be
+   * asked before the y-data is written, since writing it changes the sizes
+   * being compared. */
+  template <SeriesType t_series_type>
+  bool seriesXSizesMatch(
+      const std::vector<std::vector<float>> &y_data) const noexcept;
   /** @internal */
   template <SeriesType t_series_type>
   void plotInternal(const std::vector<std::vector<float>> &y_data,

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -315,30 +315,57 @@ void Plot::plotVerticalLines(const std::vector<float>& x_coordinates,
 }
 
 template <SeriesType t_series_type>
+bool Plot::seriesXSizesMatch(
+    const std::vector<std::vector<float>>& y_data) const noexcept {
+  auto y_data_it = y_data.begin();
+
+  for (const auto& series : *m_series) {
+    if (series->getType() != t_series_type) continue;
+
+    if (y_data_it == y_data.end()) return false;
+    if (series->getXData().size() != (y_data_it++)->size()) return false;
+  }
+
+  // Any leftover y-data belongs to a series that does not exist yet.
+  return y_data_it == y_data.end();
+}
+
+template <SeriesType t_series_type>
 void Plot::plotInternal(const std::vector<std::vector<float>>& y_data,
                         const std::vector<std::vector<float>>& x_data,
                         const SeriesAttributeList& series_attributes,
                         const bool update_y_data_only) {
   if (update_y_data_only) jassert(!m_series->empty());
 
+  // Whether the existing x-data can be kept has to be decided before the
+  // y-data is written, because writing it changes the sizes being compared.
+  //
+  // Keeping x-data of a different length would leave it - and the pixel-point
+  // indices derived from it - describing a different number of points than
+  // the series holds, so the x-data is regenerated instead.
+  const auto keep_existing_x_data =
+      update_y_data_only && seriesXSizesMatch<t_series_type>(y_data);
+
+  // Reaching this in a y-only update means the caller changed the number of
+  // values, which costs the x-data update that plotUpdateYOnly exists to
+  // avoid. It is handled, but it is worth knowing about.
+  jassert(!update_y_data_only || keep_existing_x_data);
+
   updateSeriesYData<t_series_type>(y_data, series_attributes);
 
-  if (update_y_data_only) {
-    goto skip_update_x_data_label;
-  }
+  if (!keep_existing_x_data) {
+    if (!x_data.empty()) {
+      updateSeriesXData<t_series_type>(x_data);
+    } else {
+      // Fix this for other types of lines
+      const auto gen_x_data = generateXdataRamp(y_data);
 
-  if (!x_data.empty()) {
-    updateSeriesXData<t_series_type>(x_data);
-  } else {
-    // Fix this for other types of lines
-    const auto gen_x_data = generateXdataRamp(y_data);
-
-    if (!gen_x_data.empty()) {
-      updateSeriesXData<t_series_type>(gen_x_data);
+      if (!gen_x_data.empty()) {
+        updateSeriesXData<t_series_type>(gen_x_data);
+      }
     }
   }
 
-skip_update_x_data_label:
   m_notify_components_on_update.notify();
 }
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_update_y_only_test.cpp
+++ b/tests/unit_tests/cmp_update_y_only_test.cpp
@@ -1,0 +1,116 @@
+#include <juce_core/juce_core.h>
+
+#include <vector>
+
+#include "cmp_lookandfeel.h"
+#include "cmp_plot.h"
+#include "cmp_series.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for plotUpdateYOnly when the number of y-values changes.
+ *
+ * plotUpdateYOnly skips the x-data update, which is where its speed comes
+ * from. If the caller passes a different number of values, keeping the old
+ * x-data would leave it - and the pixel-point indices derived from it -
+ * describing a different number of points than the series holds, so indices
+ * would be used to read past the end of the y-data. The x-data is regenerated
+ * in that case instead.
+ */
+SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
+  const auto make = [](const std::size_t n, const float value) {
+    return std::vector<float>(n, value);
+  };
+
+  /** Every index used to read the y-data must be inside it. */
+  const auto countOutOfRangeIndices = [](const cmp::Series& series) {
+    const auto& y_data = series.getYData();
+
+    std::size_t out_of_range = 0u;
+    for (const auto i : series.getPixelPointIndices())
+      if (i >= y_data.size()) ++out_of_range;
+
+    return out_of_range;
+  };
+
+  TEST("The same number of values keeps the existing x-data") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const std::vector<float> x_data = make(500u, 3.f);
+    plot.plot({.x = x_data, .y = make(500u, 1.f)});
+    plot.plotUpdateYOnly(make(500u, 2.f));
+
+    const auto series = getChildComponentHelper<cmp::Series>(plot);
+    expectEquals(series.size(), 1ul);
+
+    // The x-data the caller set is untouched, which is the whole point of
+    // updating only the y-data.
+    expectEqualVectors(series[0]->getXData(), x_data,
+                       [&](auto a, auto b) { expectEquals(a, b); });
+    expectEquals(series[0]->getYData().size(), std::size_t(500u));
+    expectEquals(countOutOfRangeIndices(*series[0]), std::size_t(0u));
+  }
+
+  TEST("Fewer values leaves no index past the end of the y-data") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = make(500u, 1.f)});
+    plot.plotUpdateYOnly(make(10u, 2.f));
+
+    const auto series = getChildComponentHelper<cmp::Series>(plot);
+    expectEquals(series.size(), 1ul);
+
+    expectEquals(series[0]->getYData().size(), std::size_t(10u));
+    expectEquals(series[0]->getXData().size(), std::size_t(10u));
+    expectEquals(countOutOfRangeIndices(*series[0]), std::size_t(0u));
+  }
+
+  TEST("More values keeps the x- and y-data the same length") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = make(10u, 1.f)});
+    plot.plotUpdateYOnly(make(500u, 2.f));
+
+    const auto series = getChildComponentHelper<cmp::Series>(plot);
+
+    expectEquals(series[0]->getYData().size(), std::size_t(500u));
+    expectEquals(series[0]->getXData().size(), std::size_t(500u));
+    expectEquals(countOutOfRangeIndices(*series[0]), std::size_t(0u));
+  }
+
+  TEST("Shrinking then growing again stays consistent") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = make(300u, 1.f)});
+
+    for (const std::size_t n : {50u, 700u, 20u, 300u, 1u}) {
+      plot.plotUpdateYOnly(make(n, 2.f));
+
+      const auto series = getChildComponentHelper<cmp::Series>(plot);
+
+      expectEquals(series[0]->getYData().size(), n);
+      expectEquals(series[0]->getXData().size(), n);
+      expectEquals(countOutOfRangeIndices(*series[0]), std::size_t(0u));
+    }
+  }
+
+  TEST("Multiple series each track their own size") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({{.y = make(200u, 1.f)}, {.y = make(200u, 2.f)}});
+    plot.plotUpdateYOnly({make(30u, 3.f), make(30u, 4.f)});
+
+    const auto series = getChildComponentHelper<cmp::Series>(plot);
+    expectEquals(series.size(), 2ul);
+
+    for (const auto* one : series) {
+      expectEquals(one->getYData().size(), std::size_t(30u));
+      expectEquals(one->getXData().size(), std::size_t(30u));
+      expectEquals(countOutOfRangeIndices(*one), std::size_t(0u));
+    }
+  }
+}


### PR DESCRIPTION
## The bug

`plotUpdateYOnly` skips the x-data update — that is where its speed comes
from. Nothing checked that the caller passed as many y-values as the series
already held, so the pixel-point indices, derived from the **old** x-data,
were used to read the **new** y-data:

```cpp
for (const auto i_y : pixel_points_indices)
  pixel_points[i].setY(transform.toPixel(y_data[i_y]));   // cmp_lookandfeel.cpp
```

Measured: `plot()` with 500 points, then `plotUpdateYOnly()` with 10 —

```
y_data=10  indices=251  out_of_range=245
```

**245 of 251 indices point past the end of a 10-element vector.** It does not
crash today only because shrinking a vector keeps its capacity, so the reads
land in still-allocated memory and render stale values. It is undefined
behaviour, and a genuine out-of-bounds read for a series whose capacity is
smaller.

Growing was wrong in the other direction: the x-data stayed short, so the
extra values were silently never drawn (`x_data=10 y_data=500`).

The header documented that x must be set by `plot()` first, but said nothing
about size — and variable FFT or block sizes are exactly the real-time case
this function exists for.

## The fix

`plotInternal` now decides whether the existing x-data can be kept **before**
writing the y-data, since writing it changes the sizes being compared, and
regenerates the x-data when the count changed.

The common case — same number of values — is unaffected and still skips the
x-data update, so a caller already using this correctly pays nothing: one
integer compare per series, against an N-element copy and a full
re-projection. A `jassert` fires on the slow path so the extra work is
visible while developing.

The `goto` is gone as a side effect; the x-data update is guarded by the same
condition rather than jumped over.

## Behaviour change

Passing a different number of values now regenerates the x-data as a ramp,
which **replaces x-data previously set through `plot()`**. That only affects
calls that were reading out of bounds before, and there is no meaningful
x-data to keep for a different number of points. Documented on the method.

## Tests

Five new tests, and the suite goes 124 -> 129 sections, all passing:

- unchanged size keeps caller-set x-data (the fast path still works)
- fewer values: x and y the same length, no index past the end of the y-data
- more values: same
- a sequence of changing sizes (50, 700, 20, 300, 1) stays consistent
- multiple series each track their own size
