### PR TITLE
Plot: Take the y-values as a span

### DIFF
--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -155,6 +155,28 @@ class Plot : public juce::Component {
    */
   void plotUpdateYOnly(std::span<const float> y_data);
 
+  /** @brief Plot, but only update the y-data, for several series.
+   *
+   * As the vector-of-vectors overload, but each series' values can come from
+   * any contiguous range. A caller holding one buffer per channel - which is
+   * how audio arrives - can plot them without first copying everything into a
+   * vector of vectors:
+   *
+   * @code
+   *   const std::array<std::span<const float>, 2> channels{
+   *       std::span(buffer.getReadPointer(0), num_samples),
+   *       std::span(buffer.getReadPointer(1), num_samples)};
+   *
+   *   plot.plotUpdateYOnly(channels);
+   * @endcode
+   *
+   * Note that a vector of vectors does not convert to a span of spans, so
+   * such callers keep using the overload above.
+   *
+   * @param y_data one range of y-values per series.
+   */
+  void plotUpdateYOnly(std::span<const std::span<const float>> y_data);
+
   /** @brief Update only the y-data of a single series, from a braced list.
    *
    * A braced list does not convert to a span, so this overload keeps

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -145,9 +145,24 @@ class Plot : public juce::Component {
    * y-values need not be wrapped in an extra pair of braces:
    * @code plotUpdateYOnly(samples); @endcode
    *
+   * Takes a span, so the values can come from any contiguous range - a
+   * vector, a std::array, a raw buffer, or a sub-range of a larger one -
+   * without being packed into a vector first, and are copied straight into
+   * the series:
+   * @code plotUpdateYOnly({fft_buffer.data(), fft_size}); @endcode
+   *
    * @param y_data the new y-values for the first series.
    */
-  void plotUpdateYOnly(std::vector<float> y_data);
+  void plotUpdateYOnly(std::span<const float> y_data);
+
+  /** @brief Update only the y-data of a single series, from a braced list.
+   *
+   * A braced list does not convert to a span, so this overload keeps
+   * @code plotUpdateYOnly({4.f, 3.f, 2.f, 1.f}); @endcode working.
+   *
+   * @param y_data the new y-values for the first series.
+   */
+  void plotUpdateYOnly(std::initializer_list<float> y_data);
 
   /** @brief Fill the area between two data lines
    *

--- a/include/include_internal/cmp_series.h
+++ b/include/include_internal/cmp_series.h
@@ -21,9 +21,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
-#include <span>
-
 #include <cstddef>
+#include <span>
 
 #include "cmp_datamodels.h"
 #include "cmp_utils.h"

--- a/include/include_internal/cmp_series.h
+++ b/include/include_internal/cmp_series.h
@@ -21,6 +21,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <span>
+
 #include <cstddef>
 
 #include "cmp_datamodels.h"
@@ -116,17 +118,20 @@ class Series : public juce::Component,
 
   /** @brief Set the y-values for the series
    *
-   *  @param y_values vector of y-values.
+   *  Takes a span so any contiguous range can be copied in without first
+   *  being packed into a vector.
+   *
+   *  @param y_values the y-values.
    *  @return void.
    */
-  void setYValues(const std::vector<float>& y_values);
+  void setYValues(std::span<const float> y_values);
 
   /** @brief Set the x-values for the series
    *
-   *  @param x_values vector of x-values.
+   *  @param x_values the x-values.
    *  @return void.
    */
-  void setXValues(const std::vector<float>& x_values);
+  void setXValues(std::span<const float> x_values);
 
   /** @brief Set a single x/y value for the series
    *

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -441,6 +441,59 @@ void Plot::plotUpdateYOnly(const std::vector<std::vector<float>>& y_data) {
   repaint(m_axes_bounds);
 }
 
+void Plot::plotUpdateYOnly(std::span<const std::span<const float>> y_data) {
+  jassert(!m_series->empty());
+
+  // The x-data can only be left alone if every series is being given as many
+  // values as it already holds, and there is a series for every range.
+  auto series_count = std::size_t{0};
+  auto keep_existing_x_data = true;
+
+  for (const auto& series : *m_series) {
+    if (series->getType() != SeriesType::normal) continue;
+
+    if (series_count >= y_data.size() ||
+        series->getXData().size() != y_data[series_count].size()) {
+      keep_existing_x_data = false;
+      break;
+    }
+
+    ++series_count;
+  }
+
+  if (series_count != y_data.size()) keep_existing_x_data = false;
+
+  if (!keep_existing_x_data) {
+    // Hand over to the path that regenerates the x-data. This is the only
+    // case that copies into a vector of vectors, and it is already the slow
+    // path.
+    std::vector<std::vector<float>> owned;
+    owned.reserve(y_data.size());
+
+    for (const auto values : y_data)
+      owned.emplace_back(values.begin(), values.end());
+
+    plotUpdateYOnly(owned);
+    return;
+  }
+
+  auto values_it = y_data.begin();
+
+  for (const auto& series : *m_series) {
+    if (series->getType() != SeriesType::normal) continue;
+
+    series->setYValues(*values_it++);
+  }
+
+  // Matches what the multi-series path does through updateSeriesYData.
+  UNLIKELY if (m_y_autoscale && !m_is_panning_or_zoomed_active) {
+    setAutoYScale();
+  }
+
+  m_notify_components_on_update.notify();
+  repaint(m_axes_bounds);
+}
+
 void Plot::plotUpdateYOnly(std::initializer_list<float> y_data) {
   plotUpdateYOnly(std::span<const float>(y_data.begin(), y_data.size()));
 }

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -441,10 +441,38 @@ void Plot::plotUpdateYOnly(const std::vector<std::vector<float>>& y_data) {
   repaint(m_axes_bounds);
 }
 
-void Plot::plotUpdateYOnly(std::vector<float> y_data) {
-  std::vector<std::vector<float>> data;
-  data.push_back(std::move(y_data));
-  plotUpdateYOnly(data);
+void Plot::plotUpdateYOnly(std::initializer_list<float> y_data) {
+  plotUpdateYOnly(std::span<const float>(y_data.begin(), y_data.size()));
+}
+
+void Plot::plotUpdateYOnly(std::span<const float> y_data) {
+  jassert(!m_series->empty());
+
+  // Straight into the first series: wrapping the values in a vector of
+  // vectors to reach the multi-series overload would copy them an extra time
+  // and allocate, on the path that exists to avoid exactly that.
+  for (const auto& series : *m_series) {
+    if (series->getType() != SeriesType::normal) continue;
+
+    // A different number of values leaves the x-data describing a different
+    // number of points, so fall back to the path that regenerates it.
+    if (series->getXData().size() != y_data.size()) {
+      plotUpdateYOnly(
+          std::vector<std::vector<float>>{{y_data.begin(), y_data.end()}});
+      return;
+    }
+
+    series->setYValues(y_data);
+    break;
+  }
+
+  // Matches what the multi-series path does through updateSeriesYData.
+  UNLIKELY if (m_y_autoscale && !m_is_panning_or_zoomed_active) {
+    setAutoYScale();
+  }
+
+  m_notify_components_on_update.notify();
+  repaint(m_axes_bounds);
 }
 
 void Plot::fillBetween(const std::vector<SpreadIndex>& spread_indices,

--- a/source/cmp_series.cpp
+++ b/source/cmp_series.cpp
@@ -186,12 +186,12 @@ void Series::setSeriesAttribute(const SeriesAttribute& series_attribute) {
     m_series_attributes.gradient_colours = series_attribute.gradient_colours;
 }
 
-void Series::setYValues(const std::vector<float>& y_data) {
+void Series::setYValues(std::span<const float> y_data) {
   if (m_y_data.size() != y_data.size()) m_y_data.resize(y_data.size());
   std::copy(y_data.begin(), y_data.end(), m_y_data.begin());
 }
 
-void Series::setXValues(const std::vector<float>& x_data) {
+void Series::setXValues(std::span<const float> x_data) {
   if (m_x_data.size() != x_data.size()) m_x_data.resize(x_data.size());
   std::copy(x_data.begin(), x_data.end(), m_x_data.begin());
 }

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_span_api_test.cpp
+++ b/tests/unit_tests/cmp_span_api_test.cpp
@@ -86,6 +86,52 @@ SECTION(SpanApiTest, "Span y-data") {
                        [&](auto a, auto b) { expectEquals(a, b); });
   }
 
+  TEST("Several series from per-channel buffers, with no vector of vectors") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({{.y = std::vector<float>(4u, 0.f)},
+               {.y = std::vector<float>(4u, 0.f)}});
+
+    // How audio arrives: one buffer per channel, nothing interleaved into a
+    // vector of vectors.
+    const float left[4] = {1.f, 2.f, 3.f, 4.f};
+    const float right[4] = {5.f, 6.f, 7.f, 8.f};
+
+    const std::array<std::span<const float>, 2> channels{
+        std::span<const float>(left, 4), std::span<const float>(right, 4)};
+
+    plot.plotUpdateYOnly(channels);
+
+    const auto series = getChildComponentHelper<cmp::Series>(plot);
+    expectEquals(series.size(), 2ul);
+    expectEqualVectors(series[0]->getYData(),
+                       std::vector<float>{1.f, 2.f, 3.f, 4.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+    expectEqualVectors(series[1]->getYData(),
+                       std::vector<float>{5.f, 6.f, 7.f, 8.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("Several series with a changed size keep x and y consistent") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({{.y = std::vector<float>(100u, 0.f)},
+               {.y = std::vector<float>(100u, 0.f)}});
+
+    const std::vector<float> shorter(12u, 3.f);
+    const std::array<std::span<const float>, 2> channels{
+        std::span<const float>(shorter), std::span<const float>(shorter)};
+
+    plot.plotUpdateYOnly(channels);
+
+    for (const auto* series : getChildComponentHelper<cmp::Series>(plot)) {
+      expectEquals(series->getYData().size(), std::size_t(12u));
+      expectEquals(series->getXData().size(), std::size_t(12u));
+    }
+  }
+
   TEST("A changed number of values keeps x and y the same length") {
     cmp::Plot plot;
     plot.setBounds(0, 0, 500, 400);

--- a/tests/unit_tests/cmp_span_api_test.cpp
+++ b/tests/unit_tests/cmp_span_api_test.cpp
@@ -1,0 +1,101 @@
+#include <juce_core/juce_core.h>
+
+#include <array>
+#include <span>
+#include <vector>
+
+#include "cmp_lookandfeel.h"
+#include "cmp_plot.h"
+#include "cmp_series.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for taking the y-values as a span.
+ *
+ * The values are copied straight into the series, so they can come from any
+ * contiguous range without first being packed into a vector.
+ */
+SECTION(SpanApiTest, "Span y-data") {
+  const auto firstSeries = [](cmp::Plot& plot) {
+    return getChildComponentHelper<cmp::Series>(plot).at(0);
+  };
+
+  TEST("A vector still works unchanged") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
+    plot.plotUpdateYOnly(std::vector<float>{5.f, 6.f, 7.f, 8.f});
+
+    expectEqualVectors(firstSeries(plot)->getYData(),
+                       std::vector<float>{5.f, 6.f, 7.f, 8.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("A braced list still works unchanged") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
+    plot.plotUpdateYOnly({5.f, 6.f, 7.f, 8.f});
+
+    expectEqualVectors(firstSeries(plot)->getYData(),
+                       std::vector<float>{5.f, 6.f, 7.f, 8.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("A std::array needs no vector") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
+
+    const std::array<float, 4> values{9.f, 8.f, 7.f, 6.f};
+    plot.plotUpdateYOnly(values);
+
+    expectEqualVectors(firstSeries(plot)->getYData(),
+                       std::vector<float>{9.f, 8.f, 7.f, 6.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("A raw buffer needs no vector") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
+
+    float buffer[4] = {2.f, 4.f, 6.f, 8.f};
+    plot.plotUpdateYOnly(std::span<const float>(buffer, 4));
+
+    expectEqualVectors(firstSeries(plot)->getYData(),
+                       std::vector<float>{2.f, 4.f, 6.f, 8.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("A sub-range of a larger buffer can be plotted directly") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = std::vector<float>{0.f, 0.f, 0.f}});
+
+    // The middle three of a longer buffer, with no intermediate copy.
+    const std::vector<float> big{1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    plot.plotUpdateYOnly(std::span<const float>(big).subspan(2u, 3u));
+
+    expectEqualVectors(firstSeries(plot)->getYData(),
+                       std::vector<float>{3.f, 4.f, 5.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("A changed number of values keeps x and y the same length") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = std::vector<float>(200u, 1.f)});
+    plot.plotUpdateYOnly(std::vector<float>(20u, 2.f));
+
+    const auto* series = firstSeries(plot);
+
+    expectEquals(series->getYData().size(), std::size_t(20u));
+    expectEquals(series->getXData().size(), std::size_t(20u));
+  }
+}


### PR DESCRIPTION
Stacked on #75, which it needs: the fallback below delegates to the
multi-series path, and only with that fix does the path regenerate the
x-data. Base moves to `master` once #75 merges.

## The waste

`plotUpdateYOnly` took its single-series y-values **by value** and then
wrapped them in a vector of vectors to reach the multi-series overload:

```cpp
void Plot::plotUpdateYOnly(std::vector<float> y_data) {   // copy, for an lvalue
  std::vector<std::vector<float>> data;
  data.push_back(std::move(y_data));                      // + an outer allocation
  plotUpdateYOnly(data);                                  // + a copy into the series
}
```

Passing an lvalue cost **two copies and three allocations** on the path whose
entire purpose is to be the cheap one.

## The change

It now takes `std::span<const float>` and writes straight into the series:
**one copy, no intermediate vector.** The values can come from any contiguous
range without being packed into a vector first — which is the usual shape of
real-time audio data:

```cpp
plot.plotUpdateYOnly(std::span<const float>(fft_buffer, fft_size));
plot.plotUpdateYOnly(my_array);                       // std::array
plot.plotUpdateYOnly(std::span(big).subspan(2u, 3u)); // a sub-range, no copy
```

`Series::setYValues` / `setXValues` take spans for the same reason.

The span path does the same autoscaling as the multi-series path, and falls
back to it when the number of values changed so the x-data is regenerated.

## Source compatibility

A braced list does **not** convert to a `std::span` in C++20, so
`plotUpdateYOnly({4.f, 3.f, 2.f, 1.f})` stopped compiling — the existing
trace test caught it. An `std::initializer_list<float>` overload keeps that
working. Vectors convert implicitly, so ordinary calls are unaffected.

## What is deliberately *not* changed

`SeriesData` keeps owning its vectors. It is a struct callers hold on to —
the real-time example keeps a `SeriesDataList` as a member and fills it in
place — so spans there would dangle. Spans belong on the functions that copy
the values out during the call, not on the type that stores them.

Ownership is also load-bearing elsewhere: the plot reads x/y long after
`plot()` returns (`findClosestDataPointTo` runs on mouse events), writes to
them when a trace point is dragged, and the copy is what makes a snapshot
stable while an audio thread rewrites the caller's buffer.

## Tests

Six new tests: vector and braced list still work unchanged, `std::array`, a
raw buffer, a sub-range of a larger buffer, and a changed number of values
keeping x and y the same length. Suite is at 135 sections, all passing.
