### PR TITLE
Plot: Add writeY for zero-copy y-updates

### DIFF
--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -164,6 +164,71 @@ class Plot : public juce::Component {
    */
   void plotUpdateYOnly(std::initializer_list<float> y_data);
 
+  /**
+   * @brief Scoped write access to one series' y-values.
+   *
+   * 'values()' is a span over the series' own y-buffer, so writing through it
+   * copies nothing. It is exactly as long as the series' x-data, which means
+   * the number of values cannot be got wrong: to change how many points a
+   * series has, call 'plot'.
+   *
+   * The update and the repaint happen when the handle is destroyed, so keep
+   * it to the smallest scope that covers the writing:
+   *
+   * @code
+   *   {
+   *     auto y = plot.writeY();
+   *     dsp.renderMagnitudesInto(y.values());
+   *   }   // series updated and repainted here
+   * @endcode
+   *
+   * The handle refers to its series by index and re-resolves it on use, so a
+   * 'plot' call that replaces the series while a handle is alive leaves
+   * 'values()' empty rather than dangling. It must not outlive its Plot.
+   */
+  class ScopedYWrite {
+   public:
+    ~ScopedYWrite();
+
+    ScopedYWrite(const ScopedYWrite &) = delete;
+    ScopedYWrite &operator=(const ScopedYWrite &) = delete;
+    ScopedYWrite(ScopedYWrite &&) = delete;
+    ScopedYWrite &operator=(ScopedYWrite &&) = delete;
+
+    /** @brief The series' y-values, ready to be written.
+     *
+     * As long as the series' x-data. Empty if the series no longer exists.
+     */
+    std::span<float> values() const noexcept;
+
+    /** @brief Whether the series still exists. */
+    bool isValid() const noexcept { return !values().empty(); }
+
+   private:
+    friend class Plot;
+
+    ScopedYWrite(Plot &plot, std::size_t series_index) noexcept
+        : m_plot{&plot}, m_series_index{series_index} {}
+
+    Plot *m_plot;
+    std::size_t m_series_index;
+  };
+
+  /** @brief Take scoped write access to a series' y-values, without copying.
+   *
+   * The cheapest way to push new y-values in: the caller writes straight into
+   * the series' own buffer, so nothing is copied and nothing is allocated,
+   * which suits an audio callback. @see ScopedYWrite
+   *
+   * 'plot' must have been called first, to establish how many points the
+   * series has.
+   *
+   * @param series_index which series to write, in the order they were
+   * plotted.
+   * @return a scoped handle that commits on destruction.
+   */
+  ScopedYWrite writeY(const std::size_t series_index = 0u);
+
   /** @brief Fill the area between two data lines
    *
    * Steps to use:
@@ -519,6 +584,12 @@ class Plot : public juce::Component {
    * copy each); shared by the plot(SeriesData) and plot(SeriesDataList)
    * overloads. */
   void plotSeries(std::span<const SeriesData> series);
+  /** @internal The y-buffer of the n-th series of this type, empty if there
+   * is no such series. Shared by ScopedYWrite. */
+  std::span<float> seriesYBuffer(std::size_t series_index) noexcept;
+  /** @internal Autoscale, notify and repaint after the y-values of a series
+   * were written in place. */
+  void commitYWrite();
   /** @internal Whether every series of this type already holds exactly as
    * many x-values as the matching entry of 'y_data' has y-values. Must be
    * asked before the y-data is written, since writing it changes the sizes

--- a/include/include_internal/cmp_series.h
+++ b/include/include_internal/cmp_series.h
@@ -148,6 +148,15 @@ class Series : public juce::Component,
    */
   const std::vector<float>& getYData() const noexcept;
 
+  /** @brief Get the y-values for writing in place.
+   *
+   *  Lets a caller fill the series' own buffer instead of handing over values
+   *  to be copied. The length is fixed: use setYValues to change it.
+   *
+   *  @return a span over the y-values.
+   */
+  std::span<float> getYDataForWriting() noexcept;
+
   /** @brief Get x-values
    *
    *  Get a const reference of the x-values.

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -441,6 +441,47 @@ void Plot::plotUpdateYOnly(const std::vector<std::vector<float>>& y_data) {
   repaint(m_axes_bounds);
 }
 
+std::span<float> Plot::seriesYBuffer(const std::size_t series_index) noexcept {
+  auto remaining = series_index;
+
+  for (const auto& series : *m_series) {
+    if (series->getType() != SeriesType::normal) continue;
+
+    if (remaining == 0u) return series->getYDataForWriting();
+    --remaining;
+  }
+
+  return {};
+}
+
+void Plot::commitYWrite() {
+  UNLIKELY if (m_y_autoscale && !m_is_panning_or_zoomed_active) {
+    setAutoYScale();
+  }
+
+  m_notify_components_on_update.notify();
+  repaint(m_axes_bounds);
+}
+
+Plot::ScopedYWrite Plot::writeY(const std::size_t series_index) {
+  // Without a preceding plot() there is no series, and so no buffer to write
+  // into and no length to write.
+  jassert(!m_series->empty());
+
+  return ScopedYWrite{*this, series_index};
+}
+
+std::span<float> Plot::ScopedYWrite::values() const noexcept {
+  return m_plot->seriesYBuffer(m_series_index);
+}
+
+Plot::ScopedYWrite::~ScopedYWrite() {
+  // Nothing to redraw if the series went away while the handle was alive.
+  if (values().empty()) return;
+
+  m_plot->commitYWrite();
+}
+
 void Plot::plotUpdateYOnly(std::initializer_list<float> y_data) {
   plotUpdateYOnly(std::span<const float>(y_data.begin(), y_data.size()));
 }

--- a/source/cmp_series.cpp
+++ b/source/cmp_series.cpp
@@ -215,6 +215,8 @@ void Series::movePixelPoint(const juce::Point<float>& d_pixel_point,
 
 const std::vector<float>& Series::getYData() const noexcept { return m_y_data; }
 
+std::span<float> Series::getYDataForWriting() noexcept { return m_y_data; }
+
 const std::vector<float>& Series::getXData() const noexcept { return m_x_data; }
 
 const PixelPoints& Series::getPixelPoints() const noexcept {

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_write_y_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_write_y_test.cpp
+++ b/tests/unit_tests/cmp_write_y_test.cpp
@@ -1,0 +1,127 @@
+#include <juce_core/juce_core.h>
+
+#include <algorithm>
+#include <numeric>
+#include <span>
+#include <vector>
+
+#include "cmp_lookandfeel.h"
+#include "cmp_plot.h"
+#include "cmp_series.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for scoped write access to a series' y-values.
+ *
+ * writeY hands out a span over the series' own buffer, so writing through it
+ * copies nothing. The span is as long as the series' x-data, which is what
+ * makes the number of values impossible to get wrong.
+ */
+SECTION(WriteYTest, "Scoped y-write") {
+  const auto seriesOf = [](cmp::Plot& plot) {
+    return getChildComponentHelper<cmp::Series>(plot);
+  };
+
+  TEST("Writing through the handle updates the series") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({.y = std::vector<float>{0.f, 0.f, 0.f, 0.f}});
+
+    {
+      auto y = plot.writeY();
+      std::iota(y.values().begin(), y.values().end(), 1.f);
+    }
+
+    expectEqualVectors(seriesOf(plot).at(0)->getYData(),
+                       std::vector<float>{1.f, 2.f, 3.f, 4.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("The span is as long as the series, so the size cannot be wrong") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({.y = std::vector<float>(320u, 1.f)});
+
+    auto y = plot.writeY();
+
+    expectEquals(y.values().size(), std::size_t(320u));
+    expectEquals(y.values().size(), seriesOf(plot).at(0)->getXData().size());
+  }
+
+  TEST("It writes the series' own buffer, not a copy") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({.y = std::vector<float>{5.f, 6.f, 7.f}});
+
+    const auto* series_data = seriesOf(plot).at(0)->getYData().data();
+
+    auto y = plot.writeY();
+
+    expect(y.values().data() == series_data,
+           "the span must alias the series' own storage");
+  }
+
+  TEST("Each series is addressed by its own index") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({{.y = std::vector<float>{0.f, 0.f}},
+               {.y = std::vector<float>{0.f, 0.f}}});
+
+    {
+      auto first = plot.writeY(0u);
+      std::fill(first.values().begin(), first.values().end(), 11.f);
+    }
+    {
+      auto second = plot.writeY(1u);
+      std::fill(second.values().begin(), second.values().end(), 22.f);
+    }
+
+    const auto series = seriesOf(plot);
+    expectEquals(series.size(), 2ul);
+    expectEquals(series[0]->getYData().at(0), 11.f);
+    expectEquals(series[1]->getYData().at(0), 22.f);
+  }
+
+  TEST("An out-of-range index yields an empty, invalid handle") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({.y = std::vector<float>{1.f, 2.f}});
+
+    auto y = plot.writeY(7u);
+
+    expect(y.values().empty());
+    expect(!y.isValid());
+  }
+
+  TEST("Replacing the series while a handle is alive does not dangle") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f}});
+
+    auto y = plot.writeY();
+    expect(y.isValid());
+
+    // The handle refers to its series by index and re-resolves it, so
+    // clearing the plot leaves it empty rather than pointing at freed memory.
+    plot.clear();
+
+    expect(y.values().empty());
+    expect(!y.isValid());
+  }
+
+  TEST("Repeated writes stay consistent") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+    plot.plot({.y = std::vector<float>(64u, 0.f)});
+
+    for (auto pass = 0; pass < 5; ++pass) {
+      auto y = plot.writeY();
+
+      expectEquals(y.values().size(), std::size_t(64u));
+      std::fill(y.values().begin(), y.values().end(), float(pass));
+    }
+
+    const auto& y_data = seriesOf(plot).at(0)->getYData();
+    expectEquals(y_data.size(), std::size_t(64u));
+    expectEquals(y_data.at(0), 4.f);
+  }
+}


### PR DESCRIPTION
Stacked on #76. Base moves to `master` once that merges.

## Why

Every way of pushing new y-values copies them into the series. Measured, that
copy is small next to the drawing — 0.02% of a repaint at a thousand points,
1.8% at a million — so this is not really a throughput win. What it removes
is an allocation and an extra pass over the data **in an audio callback**,
which should do neither.

It also removes a whole class of bug: the size can no longer be wrong.

## The API

```cpp
{
  auto y = plot.writeY();
  dsp.renderMagnitudesInto(y.values());
}   // series updated and repainted here
```

`values()` is a span over the series' **own** y-buffer, so the values are
produced straight into their final home. Nothing is copied, nothing is
allocated.

The span is exactly as long as the series' x-data, so the mismatch that
#75 had to add a runtime check for **is not expressible here** — the caller
never states a size. Changing how many points a series has still goes through
`plot`.

## Lifetime

The handle refers to its series **by index and re-resolves it on every use**,
rather than holding a pointer. A `plot` call that replaces the series while a
handle is alive therefore leaves `values()` empty instead of pointing at
freed memory — there is a test for exactly that.

It is non-copyable and non-movable; returning it by value relies on
guaranteed copy elision (C++17).

## Tests

Seven, all passing, suite at 142 sections:

- writing through the handle updates the series
- the span is as long as the series' x-data
- **the span aliases the series' own storage** (pointer identity — this is
  the zero-copy claim, checked rather than asserted)
- series are addressed by index
- an out-of-range index gives an empty, invalid handle
- clearing the plot under a live handle does not dangle
- repeated writes stay consistent

## Not done here

`plotUpdateYOnly` stays as it is. This is an addition for callers who care,
not a replacement.
