### PR TITLE
Plot: Add plot overloads that take ownership of the series

### DIFF
--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -92,6 +92,28 @@ class Plot : public juce::Component {
   void plot(const SeriesData &series);
 
   /**
+   * @brief Plot one or more series, taking their values.
+   *
+   * Overload for a caller handing over series it no longer needs: the x- and
+   * y-values are moved into the plot rather than copied.
+   *
+   * @code plot(std::move(my_series)); @endcode
+   *
+   * @param series the series to plot, left empty afterwards @see SeriesData
+   */
+  void plot(SeriesDataList &&series);
+
+  /**
+   * @brief Plot a single series, taking its values.
+   *
+   * Also picked for a temporary, so @code plot({.y = makeSamples()}); @endcode
+   * moves rather than copies.
+   *
+   * @param series the series to plot, left empty afterwards @see SeriesData
+   */
+  void plot(SeriesData &&series);
+
+  /**
    * @brief Remove all plotted series, clearing the plot.
    *
    * A named alias for plotting an empty list: @code plot({}); @endcode
@@ -541,6 +563,14 @@ class Plot : public juce::Component {
    * copy each); shared by the plot(SeriesData) and plot(SeriesDataList)
    * overloads. */
   void plotSeries(std::span<const SeriesData> series);
+  /** @internal Shared body of the plot overloads. With t_take_ownership the
+   * caller's series are expiring, so their values are moved rather than
+   * copied. */
+  template <bool t_take_ownership>
+  void plotSeriesInternal(
+      std::span<
+          std::conditional_t<t_take_ownership, SeriesData, const SeriesData>>
+          series);
   /** @internal Whether every series of this type already holds exactly as
    * many x-values as the matching entry of 'y_data' has y-values. Must be
    * asked before the y-data is written, since writing it changes the sizes

--- a/include/include_internal/cmp_series.h
+++ b/include/include_internal/cmp_series.h
@@ -125,12 +125,29 @@ class Series : public juce::Component,
    */
   void setYValues(std::span<const float> y_values);
 
+  /** @brief Take the y-values from an expiring vector.
+   *
+   *  Steals the storage instead of copying into the existing buffer, for
+   *  callers handing over values they no longer need.
+   *
+   *  @param y_values the y-values to take.
+   *  @return void.
+   */
+  void setYValues(std::vector<float>&& y_values);
+
   /** @brief Set the x-values for the series
    *
    *  @param x_values the x-values.
    *  @return void.
    */
   void setXValues(std::span<const float> x_values);
+
+  /** @brief Take the x-values from an expiring vector.
+   *
+   *  @param x_values the x-values to take.
+   *  @return void.
+   */
+  void setXValues(std::vector<float>&& x_values);
 
   /** @brief Set a single x/y value for the series
    *

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -385,7 +385,11 @@ std::vector<std::vector<float>> Plot::generateXdataRamp(
   return generateRamp();
 }
 
-void Plot::plotSeries(std::span<const SeriesData> series) {
+template <bool t_take_ownership>
+void Plot::plotSeriesInternal(
+    std::span<
+        std::conditional_t<t_take_ownership, SeriesData, const SeriesData>>
+        series) {
   // Validate before mutating any state, so a throw leaves the plot untouched.
   // An empty x is allowed: it auto-generates a 1..N ramp below.
   for (const auto& s : series)
@@ -405,16 +409,30 @@ void Plot::plotSeries(std::span<const SeriesData> series) {
     if (component->getType() != SeriesType::normal) continue;
     if (series_it == series.end()) break;
 
-    const auto& s = *series_it++;
-    component->setYValues(s.y);
+    auto& s = *series_it++;
 
-    if (s.x.empty()) {
-      // No x supplied: use a 1..N ramp, matching generateXdataRamp.
-      std::vector<float> ramp(s.y.size());
+    // No x supplied: use a 1..N ramp, matching generateXdataRamp. The ramp is
+    // built here and always moved, since nothing else owns it.
+    const auto needs_ramp = s.x.empty();
+    std::vector<float> ramp;
+
+    if (needs_ramp) {
+      ramp.resize(s.y.size());
       std::iota(ramp.begin(), ramp.end(), 1.0f);
-      component->setXValues(ramp);
+    }
+
+    if constexpr (t_take_ownership) {
+      // The caller's bundle is expiring, so its storage is taken rather than
+      // copied.
+      component->setYValues(std::move(s.y));
+      component->setXValues(needs_ramp ? std::move(ramp) : std::move(s.x));
     } else {
-      component->setXValues(s.x);
+      component->setYValues(s.y);
+
+      if (needs_ramp)
+        component->setXValues(std::move(ramp));
+      else
+        component->setXValues(s.x);
     }
 
     component->setSeriesAttribute(s.attribute);
@@ -430,9 +448,21 @@ void Plot::plotSeries(std::span<const SeriesData> series) {
   repaint();
 }
 
+void Plot::plotSeries(std::span<const SeriesData> series) {
+  plotSeriesInternal<false>(series);
+}
+
 void Plot::plot(const SeriesDataList& series) { plotSeries(series); }
 
 void Plot::plot(const SeriesData& series) { plotSeries({&series, 1}); }
+
+void Plot::plot(SeriesDataList&& series) {
+  plotSeriesInternal<true>(std::span<SeriesData>{series});
+}
+
+void Plot::plot(SeriesData&& series) {
+  plotSeriesInternal<true>(std::span<SeriesData>{&series, 1});
+}
 
 void Plot::clear() { plotSeries({}); }
 

--- a/source/cmp_series.cpp
+++ b/source/cmp_series.cpp
@@ -191,9 +191,17 @@ void Series::setYValues(std::span<const float> y_data) {
   std::copy(y_data.begin(), y_data.end(), m_y_data.begin());
 }
 
+void Series::setYValues(std::vector<float>&& y_data) {
+  m_y_data = std::move(y_data);
+}
+
 void Series::setXValues(std::span<const float> x_data) {
   if (m_x_data.size() != x_data.size()) m_x_data.resize(x_data.size());
   std::copy(x_data.begin(), x_data.end(), m_x_data.begin());
+}
+
+void Series::setXValues(std::vector<float>&& x_data) {
+  m_x_data = std::move(x_data);
 }
 
 bool Series::setXYValue(const juce::Point<float>& xy_value, size_t index) {

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_plot_sink_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_plot_sink_test.cpp
+++ b/tests/unit_tests/cmp_plot_sink_test.cpp
@@ -1,0 +1,105 @@
+#include <juce_core/juce_core.h>
+
+#include <utility>
+#include <vector>
+
+#include "cmp_lookandfeel.h"
+#include "cmp_plot.h"
+#include "cmp_series.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for the plot overloads that take ownership.
+ *
+ * A caller handing over series it no longer needs has its x- and y-values
+ * moved into the plot rather than copied.
+ */
+SECTION(PlotSinkTest, "Plot sink overloads") {
+  const auto seriesOf = [](cmp::Plot& plot) {
+    return getChildComponentHelper<cmp::Series>(plot);
+  };
+
+  const auto expectEqualsLambda = [&](auto a, auto b) { expectEquals(a, b); };
+
+  TEST("Moving a single series plots the same values") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    cmp::SeriesData series{.x = {1.f, 2.f, 3.f}, .y = {4.f, 5.f, 6.f}};
+    plot.plot(std::move(series));
+
+    const auto plotted = seriesOf(plot);
+    expectEquals(plotted.size(), 1ul);
+    expectEqualVectors(plotted[0]->getXData(), {1.f, 2.f, 3.f},
+                       expectEqualsLambda);
+    expectEqualVectors(plotted[0]->getYData(), {4.f, 5.f, 6.f},
+                       expectEqualsLambda);
+  }
+
+  TEST("Moving takes the caller's storage rather than copying it") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    cmp::SeriesData series{.y = std::vector<float>(256u, 7.f)};
+    const auto* source = series.y.data();
+
+    plot.plot(std::move(series));
+
+    // The series now holds the very buffer the caller allocated.
+    expect(seriesOf(plot).at(0)->getYData().data() == source,
+           "the plot must take the caller's buffer, not copy it");
+  }
+
+  TEST("Moving a list plots every series") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    cmp::SeriesDataList list{{.y = {1.f, 2.f}}, {.y = {3.f, 4.f}}};
+    plot.plot(std::move(list));
+
+    const auto plotted = seriesOf(plot);
+    expectEquals(plotted.size(), 2ul);
+    expectEqualVectors(plotted[0]->getYData(), {1.f, 2.f}, expectEqualsLambda);
+    expectEqualVectors(plotted[1]->getYData(), {3.f, 4.f}, expectEqualsLambda);
+  }
+
+  TEST("A moved series still gets its x-ramp generated") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot(cmp::SeriesData{.y = {9.f, 9.f, 9.f, 9.f}});
+
+    expectEqualVectors(seriesOf(plot).at(0)->getXData(), {1.f, 2.f, 3.f, 4.f},
+                       expectEqualsLambda);
+  }
+
+  TEST("Copying still works and leaves the caller's series intact") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const cmp::SeriesData series{.x = {1.f, 2.f}, .y = {8.f, 9.f}};
+    plot.plot(series);
+
+    // The const overload must not have disturbed the caller's data.
+    expectEquals(series.x.size(), std::size_t(2u));
+    expectEquals(series.y.size(), std::size_t(2u));
+
+    expectEqualVectors(seriesOf(plot).at(0)->getYData(), {8.f, 9.f},
+                       expectEqualsLambda);
+  }
+
+  TEST("A mismatched x and y still throws when moved") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    auto plotMismatched = [&] {
+      plot.plot(cmp::SeriesData{.x = {1.f, 2.f, 3.f}, .y = {1.f, 2.f}});
+    };
+
+    try {
+      plotMismatched();
+      expect(false, "a mismatched x and y must throw");
+    } catch (const std::invalid_argument&) {
+      expect(true);
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #77 (which is on #76). Base moves down the stack as they merge.

## Why

`plot` copied the caller's x- and y-values into the series unconditionally,
including when the caller was handing over a temporary it had no further use
for. Overloads taking `SeriesData&&` and `SeriesDataList&&` move the storage
instead:

```cpp
plot.plot(std::move(my_series));
plot.plot({.y = makeSamples()});   // a temporary, so also moved
```

## How

The shared body is templated on whether the caller's series are expiring, so
the copying and moving paths cannot drift apart:

```cpp
if constexpr (t_take_ownership) {
  component->setYValues(std::move(s.y));
  ...
```

The generated x-ramp is always moved, since nothing else owns it — a small
win on the copying path too.

`Series` gains `vector&&` overloads of `setYValues` / `setXValues` that steal
the storage rather than copying into the existing buffer.

## Tests

Six, all passing, suite at 148 sections:

- moving a single series and a list plot the same values
- **the plot takes the caller's buffer rather than copying it** (pointer
  identity — the actual claim, checked rather than asserted)
- a moved series still gets its x-ramp generated
- the copying overload leaves the caller's series intact
- a mismatched x and y still throws when moved

## Scope

This is the last of the four pieces discussed. Ordered by what they actually
buy:

| | what it removes |
|---|---|
| #76 span | a whole redundant copy + allocation on the y-only path |
| #77 `writeY` | the remaining copy, and the possibility of a wrong size |
| this | a copy for callers handing over data they are done with |

`SeriesData` still owns its vectors throughout. Borrowing there would trade
correctness — the plot reads x/y on later mouse events and writes them when a
trace point is dragged — for a copy measured at 0.02–1.8% of a repaint.
