### PR TITLE
Plot: Return handles from plot, and batch series updates

### DIFF
--- a/include/include/cmp_datamodels.h
+++ b/include/include/cmp_datamodels.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <span>
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -36,6 +37,7 @@ namespace cmp {
 
 /*============================================================================*/
 
+class Plot;
 class Series;
 class Grid;
 class Frame;
@@ -501,6 +503,199 @@ struct SeriesData {
 
   /** Optional per-series styling. @see SeriesAttribute */
   SeriesAttribute attribute{};
+};
+
+/**
+ * @brief Scoped write access to one of a series' value arrays.
+ *
+ * 'values()' is a span over the series' own buffer, so writing through it
+ * copies nothing. It is exactly as long as the series, which means the number
+ * of values cannot be got wrong: to change how many points a series has, plot
+ * it again.
+ *
+ * The update happens when the handle is destroyed, so keep it to the smallest
+ * scope that covers the writing:
+ *
+ * @code
+ *   {
+ *     auto y = series.writeY();
+ *     dsp.renderMagnitudesInto(y.values());
+ *   }   // series updated and repainted here
+ * @endcode
+ *
+ * Only the y-values can be written this way today. The type is not named for
+ * an axis so that writing the x-values, should it ever be wanted, is an
+ * addition rather than a rename - but note that the downsampler locates the
+ * visible range by binary-searching the x-data, so handing out a writable
+ * x-buffer would let a caller silently break that ordering. The y-values
+ * carry no such invariant, which is what makes writing them safe.
+ */
+class ScopedSeriesWrite {
+ public:
+  ~ScopedSeriesWrite();
+
+  ScopedSeriesWrite(const ScopedSeriesWrite&) = delete;
+  ScopedSeriesWrite& operator=(const ScopedSeriesWrite&) = delete;
+  ScopedSeriesWrite(ScopedSeriesWrite&&) = delete;
+  ScopedSeriesWrite& operator=(ScopedSeriesWrite&&) = delete;
+
+  /** @brief The series' y-values, ready to be written. Empty if the series no
+   * longer exists. */
+  std::span<float> values() const noexcept;
+
+  /** @brief Whether the series still exists. */
+  bool isValid() const noexcept { return !values().empty(); }
+
+ private:
+  friend class SeriesHandle;
+
+  ScopedSeriesWrite(Plot& plot, const std::size_t series_index) noexcept
+      : m_plot{&plot}, m_series_index{series_index} {}
+
+  Plot* m_plot;
+  std::size_t m_series_index;
+};
+
+/**
+ * @brief Batches several series updates into one.
+ *
+ * Updating a series rescales the axes, notifies the other components and
+ * repaints. Doing that once per series is wasteful when several are updated
+ * together, so while an update is open the work is deferred and done once when
+ * it closes:
+ *
+ * @code
+ *   {
+ *     auto update = plot.beginUpdate();
+ *     left.setY(left_samples);
+ *     right.setY(right_samples);
+ *   }   // rescaled, notified and repainted once
+ * @endcode
+ *
+ * Nesting is allowed; the work happens when the outermost one closes.
+ */
+class ScopedPlotUpdate {
+ public:
+  ~ScopedPlotUpdate();
+
+  ScopedPlotUpdate(const ScopedPlotUpdate&) = delete;
+  ScopedPlotUpdate& operator=(const ScopedPlotUpdate&) = delete;
+  ScopedPlotUpdate(ScopedPlotUpdate&&) = delete;
+  ScopedPlotUpdate& operator=(ScopedPlotUpdate&&) = delete;
+
+ private:
+  friend class Plot;
+
+  explicit ScopedPlotUpdate(Plot& plot) noexcept;
+
+  Plot* m_plot;
+};
+
+/**
+ * @brief A reference to one plotted series.
+ *
+ * Returned by 'Plot::plot', which is what makes the ordering safe: there is no
+ * way to update a series without first having plotted one. A handle is cheap
+ * to copy and refers to its series by position, re-resolving it on use, so
+ * plotting again while a handle is held leaves it invalid rather than
+ * dangling. It must not outlive its Plot.
+ */
+class SeriesHandle {
+ public:
+  /** @brief How many points the series holds. Zero if it no longer exists. */
+  std::size_t size() const noexcept;
+
+  /** @brief Whether the series still exists. */
+  bool isValid() const noexcept { return size() != 0u; }
+
+  /** @brief Replace the y-values, keeping the x-values.
+   *
+   * Pass as many values as 'size()'; a different number is handled but costs
+   * the x-data update this exists to avoid.
+   *
+   * @param y_values the new y-values.
+   */
+  void setY(std::span<const float> y_values) const;
+
+  /** @brief Take scoped write access to the y-values, without copying.
+   *
+   * @see ScopedSeriesWrite
+   */
+  ScopedSeriesWrite writeY() const noexcept;
+
+ private:
+  friend class Plot;
+  friend class SeriesHandles;
+
+  SeriesHandle(Plot& plot, const std::size_t index) noexcept
+      : m_plot{&plot}, m_index{index} {}
+
+  Plot* m_plot;
+  std::size_t m_index;
+};
+
+/**
+ * @brief The series of a plot, as a range of handles.
+ *
+ * Holds no storage of its own - the handles are made on demand - so returning
+ * it from 'Plot::plot' costs nothing even when the caller ignores it.
+ */
+class SeriesHandles {
+ public:
+  std::size_t size() const noexcept { return m_count; }
+  bool empty() const noexcept { return m_count == 0u; }
+
+  SeriesHandle operator[](const std::size_t index) const noexcept {
+    return SeriesHandle{*m_plot, index};
+  }
+
+  /** @brief Replace the y-values of every series, in one update.
+   *
+   * The batching is the point: updating the series one at a time rescales and
+   * refreshes once per series, which costs far more than doing it once for all
+   * of them. This does the batching for the caller so it cannot be forgotten.
+   *
+   * @code
+   *   channels.setY(std::array{left, right});
+   * @endcode
+   *
+   * @param y_values one range of y-values per series.
+   */
+  void setY(std::span<const std::span<const float>> y_values) const;
+
+  /** @brief Iteration support, so the handles can be walked directly. */
+  class Iterator {
+   public:
+    Iterator(Plot& plot, const std::size_t index) noexcept
+        : m_plot{&plot}, m_index{index} {}
+
+    SeriesHandle operator*() const noexcept {
+      return SeriesHandle{*m_plot, m_index};
+    }
+    Iterator& operator++() noexcept {
+      ++m_index;
+      return *this;
+    }
+    bool operator!=(const Iterator& other) const noexcept {
+      return m_index != other.m_index;
+    }
+
+   private:
+    Plot* m_plot;
+    std::size_t m_index;
+  };
+
+  Iterator begin() const noexcept { return Iterator{*m_plot, 0u}; }
+  Iterator end() const noexcept { return Iterator{*m_plot, m_count}; }
+
+ private:
+  friend class Plot;
+
+  SeriesHandles(Plot& plot, const std::size_t count) noexcept
+      : m_plot{&plot}, m_count{count} {}
+
+  Plot* m_plot;
+  std::size_t m_count;
 };
 
 /** @brief A struct that defines between which two series the area is

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -36,8 +36,10 @@ namespace cmp {
  * @see LogLog
  */
 class Plot : public juce::Component {
+  // These are the handles Plot vends; they reach its internals so that the
+  // internals need not be public. SeriesHandles is deliberately absent - it
+  // goes through SeriesHandle's public interface instead.
   friend class SeriesHandle;
-  friend class SeriesHandles;
   friend class ScopedSeriesWrite;
   friend class ScopedPlotUpdate;
 

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -49,6 +49,196 @@ class Plot : public juce::Component {
   Plot(const Scaling x_scaling = Scaling::linear,
        const Scaling y_scaling = Scaling::linear);
 
+  class SeriesHandle;
+
+  /**
+   * @brief Scoped write access to one series' y-values.
+   *
+   * 'values()' is a span over the series' own y-buffer, so writing through it
+   * copies nothing. It is exactly as long as the series, which means the
+   * number of values cannot be got wrong: to change how many points a series
+   * has, plot it again.
+   *
+   * The update happens when the handle is destroyed, so keep it to the
+   * smallest scope that covers the writing:
+   *
+   * @code
+   *   {
+   *     auto y = series.write();
+   *     dsp.renderMagnitudesInto(y.values());
+   *   }   // series updated and repainted here
+   * @endcode
+   */
+  class ScopedYWrite {
+   public:
+    ~ScopedYWrite();
+
+    ScopedYWrite(const ScopedYWrite &) = delete;
+    ScopedYWrite &operator=(const ScopedYWrite &) = delete;
+    ScopedYWrite(ScopedYWrite &&) = delete;
+    ScopedYWrite &operator=(ScopedYWrite &&) = delete;
+
+    /** @brief The series' y-values, ready to be written. Empty if the series
+     * no longer exists. */
+    std::span<float> values() const noexcept;
+
+    /** @brief Whether the series still exists. */
+    bool isValid() const noexcept { return !values().empty(); }
+
+   private:
+    friend class SeriesHandle;
+
+    ScopedYWrite(Plot &plot, std::size_t series_index) noexcept
+        : m_plot{&plot}, m_series_index{series_index} {}
+
+    Plot *m_plot;
+    std::size_t m_series_index;
+  };
+
+  /**
+   * @brief Batches several series updates into one.
+   *
+   * Updating a series rescales the axes, notifies the other components and
+   * repaints. Doing that once per series is wasteful when several are updated
+   * together, so while an update is open the work is deferred and done once
+   * when it closes:
+   *
+   * @code
+   *   {
+   *     auto update = plot.beginUpdate();
+   *     left.setY(left_samples);
+   *     right.setY(right_samples);
+   *   }   // rescaled, notified and repainted once
+   * @endcode
+   *
+   * Nesting is allowed; the work happens when the outermost one closes.
+   */
+  class ScopedUpdate {
+   public:
+    ~ScopedUpdate();
+
+    ScopedUpdate(const ScopedUpdate &) = delete;
+    ScopedUpdate &operator=(const ScopedUpdate &) = delete;
+    ScopedUpdate(ScopedUpdate &&) = delete;
+    ScopedUpdate &operator=(ScopedUpdate &&) = delete;
+
+   private:
+    friend class Plot;
+
+    explicit ScopedUpdate(Plot &plot) noexcept;
+
+    Plot *m_plot;
+  };
+
+  /**
+   * @brief A reference to one plotted series.
+   *
+   * Returned by 'plot', which is what makes the ordering safe: there is no
+   * way to update a series without first having plotted one. A handle is
+   * cheap to copy and refers to its series by position, re-resolving it on
+   * use, so plotting again while a handle is held leaves it invalid rather
+   * than dangling. It must not outlive its Plot.
+   */
+  class SeriesHandle {
+   public:
+    /** @brief How many points the series holds. Zero if it no longer
+     * exists. */
+    std::size_t size() const noexcept;
+
+    /** @brief Whether the series still exists. */
+    bool isValid() const noexcept { return size() != 0u; }
+
+    /** @brief Replace the y-values, keeping the x-values.
+     *
+     * Pass as many values as 'size()'; a different number is handled but
+     * costs the x-data update this exists to avoid.
+     *
+     * @param y_values the new y-values.
+     */
+    void setY(std::span<const float> y_values) const;
+
+    /** @brief Take scoped write access to the y-values, without copying.
+     *
+     * @see ScopedYWrite
+     */
+    ScopedYWrite write() const noexcept;
+
+   private:
+    friend class Plot;
+    friend class SeriesHandles;
+
+    SeriesHandle(Plot &plot, std::size_t index) noexcept
+        : m_plot{&plot}, m_index{index} {}
+
+    Plot *m_plot;
+    std::size_t m_index;
+  };
+
+  /**
+   * @brief The series of a plot, as a range of handles.
+   *
+   * Holds no storage of its own - the handles are made on demand - so
+   * returning it from 'plot' costs nothing even when the caller ignores it.
+   */
+  class SeriesHandles {
+   public:
+    std::size_t size() const noexcept { return m_count; }
+    bool empty() const noexcept { return m_count == 0u; }
+
+    SeriesHandle operator[](const std::size_t index) const noexcept {
+      return SeriesHandle{*m_plot, index};
+    }
+
+    /** @brief Replace the y-values of every series, in one update.
+     *
+     * The batching is the point: updating the series one at a time rescales
+     * and refreshes once per series, which costs far more than doing it once
+     * for all of them. This does the batching for the caller so it cannot be
+     * forgotten.
+     *
+     * @code
+     *   channels.setY(std::array{left, right});
+     * @endcode
+     *
+     * @param y_values one range of y-values per series.
+     */
+    void setY(std::span<const std::span<const float>> y_values) const;
+
+    /** @brief Iteration support, so the handles can be walked directly. */
+    class Iterator {
+     public:
+      Iterator(Plot &plot, const std::size_t index) noexcept
+          : m_plot{&plot}, m_index{index} {}
+
+      SeriesHandle operator*() const noexcept {
+        return SeriesHandle{*m_plot, m_index};
+      }
+      Iterator &operator++() noexcept {
+        ++m_index;
+        return *this;
+      }
+      bool operator!=(const Iterator &other) const noexcept {
+        return m_index != other.m_index;
+      }
+
+     private:
+      Plot *m_plot;
+      std::size_t m_index;
+    };
+
+    Iterator begin() const noexcept { return Iterator{*m_plot, 0u}; }
+    Iterator end() const noexcept { return Iterator{*m_plot, m_count}; }
+
+   private:
+    friend class Plot;
+
+    SeriesHandles(Plot &plot, const std::size_t count) noexcept
+        : m_plot{&plot}, m_count{count} {}
+
+    Plot *m_plot;
+    std::size_t m_count;
+  };
+
   /**
    * @brief Set the X-limits
    * @param min minimum value
@@ -78,8 +268,9 @@ class Plot : public juce::Component {
    * @endcode
    *
    * @param series the series to plot @see SeriesData
+   * @return handles to the plotted series, for updating them afterwards
    */
-  void plot(const SeriesDataList &series);
+  SeriesHandles plot(const SeriesDataList &series);
 
   /**
    * @brief Plot a single series.
@@ -88,8 +279,29 @@ class Plot : public juce::Component {
    * pair of braces: @code plot({.y = samples}); @endcode
    *
    * @param series the series to plot @see SeriesData
+   * @return a handle to the plotted series, for updating it afterwards
    */
-  void plot(const SeriesData &series);
+  SeriesHandle plot(const SeriesData &series);
+
+  /**
+   * @brief Get a handle to an already plotted series.
+   *
+   * For code that plots in one place and updates in another, so the handle
+   * need not be carried around. An index with no series gives an invalid
+   * handle rather than undefined behaviour.
+   *
+   * @param series_index which series, in the order they were plotted.
+   * @return a handle to that series.
+   */
+  SeriesHandle series(const std::size_t series_index) noexcept;
+
+  /**
+   * @brief Batch several series updates into one rescale and repaint.
+   *
+   * @see ScopedUpdate
+   * @return a scoped handle that commits on destruction.
+   */
+  ScopedUpdate beginUpdate() noexcept;
 
   /**
    * @brief Remove all plotted series, clearing the plot.
@@ -541,6 +753,17 @@ class Plot : public juce::Component {
    * copy each); shared by the plot(SeriesData) and plot(SeriesDataList)
    * overloads. */
   void plotSeries(std::span<const SeriesData> series);
+  /** @internal Replace the y-values of the n-th normal series, regenerating
+   * its x-data if the number of values changed. */
+  void updateSeriesYAt(std::span<const float> y_data, std::size_t series_index);
+  /** @internal The y-buffer of the n-th normal series, empty if there is no
+   * such series. Shared by SeriesHandle and ScopedYWrite. */
+  std::span<float> seriesYBuffer(std::size_t series_index) noexcept;
+  /** @internal How many normal series are plotted. */
+  std::size_t normalSeriesCount() const noexcept;
+  /** @internal Rescale, notify and repaint after series were updated in
+   * place. Deferred while a ScopedUpdate is open. */
+  void commitSeriesUpdate();
   /** @internal Whether every series of this type already holds exactly as
    * many x-values as the matching entry of 'y_data' has y-values. Must be
    * asked before the y-data is written, since writing it changes the sizes
@@ -630,6 +853,11 @@ class Plot : public juce::Component {
   bool m_x_autoscale = true;
   bool m_y_autoscale = true;
   bool m_is_panning_or_zoomed_active = false;
+  /** How many ScopedUpdates are open. While non-zero, series updates defer
+   * their rescale and repaint to the outermost one. */
+  int m_open_update_count = 0;
+  /** Whether a deferred update is waiting to be committed. */
+  bool m_series_update_pending = false;
 };
 
 /**

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -52,9 +52,9 @@ class Plot : public juce::Component {
   class SeriesHandle;
 
   /**
-   * @brief Scoped write access to one series' y-values.
+   * @brief Scoped write access to one of a series' value arrays.
    *
-   * 'values()' is a span over the series' own y-buffer, so writing through it
+   * 'values()' is a span over the series' own buffer, so writing through it
    * copies nothing. It is exactly as long as the series, which means the
    * number of values cannot be got wrong: to change how many points a series
    * has, plot it again.
@@ -64,19 +64,26 @@ class Plot : public juce::Component {
    *
    * @code
    *   {
-   *     auto y = series.write();
+   *     auto y = series.writeY();
    *     dsp.renderMagnitudesInto(y.values());
    *   }   // series updated and repainted here
    * @endcode
+   *
+   * Only the y-values can be written this way today. The type is not named
+   * for an axis so that writing the x-values, should it ever be wanted, is an
+   * addition rather than a rename - but note that the downsampler locates the
+   * visible range by binary-searching the x-data, so handing out a writable
+   * x-buffer would let a caller silently break that ordering. The y-values
+   * carry no such invariant, which is what makes writing them safe.
    */
-  class ScopedYWrite {
+  class ScopedWrite {
    public:
-    ~ScopedYWrite();
+    ~ScopedWrite();
 
-    ScopedYWrite(const ScopedYWrite &) = delete;
-    ScopedYWrite &operator=(const ScopedYWrite &) = delete;
-    ScopedYWrite(ScopedYWrite &&) = delete;
-    ScopedYWrite &operator=(ScopedYWrite &&) = delete;
+    ScopedWrite(const ScopedWrite &) = delete;
+    ScopedWrite &operator=(const ScopedWrite &) = delete;
+    ScopedWrite(ScopedWrite &&) = delete;
+    ScopedWrite &operator=(ScopedWrite &&) = delete;
 
     /** @brief The series' y-values, ready to be written. Empty if the series
      * no longer exists. */
@@ -88,7 +95,7 @@ class Plot : public juce::Component {
    private:
     friend class SeriesHandle;
 
-    ScopedYWrite(Plot &plot, std::size_t series_index) noexcept
+    ScopedWrite(Plot &plot, std::size_t series_index) noexcept
         : m_plot{&plot}, m_series_index{series_index} {}
 
     Plot *m_plot;
@@ -159,9 +166,9 @@ class Plot : public juce::Component {
 
     /** @brief Take scoped write access to the y-values, without copying.
      *
-     * @see ScopedYWrite
+     * @see ScopedWrite
      */
-    ScopedYWrite write() const noexcept;
+    ScopedWrite writeY() const noexcept;
 
    private:
     friend class Plot;
@@ -757,7 +764,7 @@ class Plot : public juce::Component {
    * its x-data if the number of values changed. */
   void updateSeriesYAt(std::span<const float> y_data, std::size_t series_index);
   /** @internal The y-buffer of the n-th normal series, empty if there is no
-   * such series. Shared by SeriesHandle and ScopedYWrite. */
+   * such series. Shared by SeriesHandle and ScopedWrite. */
   std::span<float> seriesYBuffer(std::size_t series_index) noexcept;
   /** @internal How many normal series are plotted. */
   std::size_t normalSeriesCount() const noexcept;

--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -36,6 +36,11 @@ namespace cmp {
  * @see LogLog
  */
 class Plot : public juce::Component {
+  friend class SeriesHandle;
+  friend class SeriesHandles;
+  friend class ScopedSeriesWrite;
+  friend class ScopedPlotUpdate;
+
  public:
   /** Destructor, making sure to set the lookandfeel in all subcomponents to
    * nullptr. */
@@ -48,203 +53,6 @@ class Plot : public juce::Component {
    */
   Plot(const Scaling x_scaling = Scaling::linear,
        const Scaling y_scaling = Scaling::linear);
-
-  class SeriesHandle;
-
-  /**
-   * @brief Scoped write access to one of a series' value arrays.
-   *
-   * 'values()' is a span over the series' own buffer, so writing through it
-   * copies nothing. It is exactly as long as the series, which means the
-   * number of values cannot be got wrong: to change how many points a series
-   * has, plot it again.
-   *
-   * The update happens when the handle is destroyed, so keep it to the
-   * smallest scope that covers the writing:
-   *
-   * @code
-   *   {
-   *     auto y = series.writeY();
-   *     dsp.renderMagnitudesInto(y.values());
-   *   }   // series updated and repainted here
-   * @endcode
-   *
-   * Only the y-values can be written this way today. The type is not named
-   * for an axis so that writing the x-values, should it ever be wanted, is an
-   * addition rather than a rename - but note that the downsampler locates the
-   * visible range by binary-searching the x-data, so handing out a writable
-   * x-buffer would let a caller silently break that ordering. The y-values
-   * carry no such invariant, which is what makes writing them safe.
-   */
-  class ScopedWrite {
-   public:
-    ~ScopedWrite();
-
-    ScopedWrite(const ScopedWrite &) = delete;
-    ScopedWrite &operator=(const ScopedWrite &) = delete;
-    ScopedWrite(ScopedWrite &&) = delete;
-    ScopedWrite &operator=(ScopedWrite &&) = delete;
-
-    /** @brief The series' y-values, ready to be written. Empty if the series
-     * no longer exists. */
-    std::span<float> values() const noexcept;
-
-    /** @brief Whether the series still exists. */
-    bool isValid() const noexcept { return !values().empty(); }
-
-   private:
-    friend class SeriesHandle;
-
-    ScopedWrite(Plot &plot, std::size_t series_index) noexcept
-        : m_plot{&plot}, m_series_index{series_index} {}
-
-    Plot *m_plot;
-    std::size_t m_series_index;
-  };
-
-  /**
-   * @brief Batches several series updates into one.
-   *
-   * Updating a series rescales the axes, notifies the other components and
-   * repaints. Doing that once per series is wasteful when several are updated
-   * together, so while an update is open the work is deferred and done once
-   * when it closes:
-   *
-   * @code
-   *   {
-   *     auto update = plot.beginUpdate();
-   *     left.setY(left_samples);
-   *     right.setY(right_samples);
-   *   }   // rescaled, notified and repainted once
-   * @endcode
-   *
-   * Nesting is allowed; the work happens when the outermost one closes.
-   */
-  class ScopedUpdate {
-   public:
-    ~ScopedUpdate();
-
-    ScopedUpdate(const ScopedUpdate &) = delete;
-    ScopedUpdate &operator=(const ScopedUpdate &) = delete;
-    ScopedUpdate(ScopedUpdate &&) = delete;
-    ScopedUpdate &operator=(ScopedUpdate &&) = delete;
-
-   private:
-    friend class Plot;
-
-    explicit ScopedUpdate(Plot &plot) noexcept;
-
-    Plot *m_plot;
-  };
-
-  /**
-   * @brief A reference to one plotted series.
-   *
-   * Returned by 'plot', which is what makes the ordering safe: there is no
-   * way to update a series without first having plotted one. A handle is
-   * cheap to copy and refers to its series by position, re-resolving it on
-   * use, so plotting again while a handle is held leaves it invalid rather
-   * than dangling. It must not outlive its Plot.
-   */
-  class SeriesHandle {
-   public:
-    /** @brief How many points the series holds. Zero if it no longer
-     * exists. */
-    std::size_t size() const noexcept;
-
-    /** @brief Whether the series still exists. */
-    bool isValid() const noexcept { return size() != 0u; }
-
-    /** @brief Replace the y-values, keeping the x-values.
-     *
-     * Pass as many values as 'size()'; a different number is handled but
-     * costs the x-data update this exists to avoid.
-     *
-     * @param y_values the new y-values.
-     */
-    void setY(std::span<const float> y_values) const;
-
-    /** @brief Take scoped write access to the y-values, without copying.
-     *
-     * @see ScopedWrite
-     */
-    ScopedWrite writeY() const noexcept;
-
-   private:
-    friend class Plot;
-    friend class SeriesHandles;
-
-    SeriesHandle(Plot &plot, std::size_t index) noexcept
-        : m_plot{&plot}, m_index{index} {}
-
-    Plot *m_plot;
-    std::size_t m_index;
-  };
-
-  /**
-   * @brief The series of a plot, as a range of handles.
-   *
-   * Holds no storage of its own - the handles are made on demand - so
-   * returning it from 'plot' costs nothing even when the caller ignores it.
-   */
-  class SeriesHandles {
-   public:
-    std::size_t size() const noexcept { return m_count; }
-    bool empty() const noexcept { return m_count == 0u; }
-
-    SeriesHandle operator[](const std::size_t index) const noexcept {
-      return SeriesHandle{*m_plot, index};
-    }
-
-    /** @brief Replace the y-values of every series, in one update.
-     *
-     * The batching is the point: updating the series one at a time rescales
-     * and refreshes once per series, which costs far more than doing it once
-     * for all of them. This does the batching for the caller so it cannot be
-     * forgotten.
-     *
-     * @code
-     *   channels.setY(std::array{left, right});
-     * @endcode
-     *
-     * @param y_values one range of y-values per series.
-     */
-    void setY(std::span<const std::span<const float>> y_values) const;
-
-    /** @brief Iteration support, so the handles can be walked directly. */
-    class Iterator {
-     public:
-      Iterator(Plot &plot, const std::size_t index) noexcept
-          : m_plot{&plot}, m_index{index} {}
-
-      SeriesHandle operator*() const noexcept {
-        return SeriesHandle{*m_plot, m_index};
-      }
-      Iterator &operator++() noexcept {
-        ++m_index;
-        return *this;
-      }
-      bool operator!=(const Iterator &other) const noexcept {
-        return m_index != other.m_index;
-      }
-
-     private:
-      Plot *m_plot;
-      std::size_t m_index;
-    };
-
-    Iterator begin() const noexcept { return Iterator{*m_plot, 0u}; }
-    Iterator end() const noexcept { return Iterator{*m_plot, m_count}; }
-
-   private:
-    friend class Plot;
-
-    SeriesHandles(Plot &plot, const std::size_t count) noexcept
-        : m_plot{&plot}, m_count{count} {}
-
-    Plot *m_plot;
-    std::size_t m_count;
-  };
 
   /**
    * @brief Set the X-limits
@@ -305,10 +113,10 @@ class Plot : public juce::Component {
   /**
    * @brief Batch several series updates into one rescale and repaint.
    *
-   * @see ScopedUpdate
+   * @see ScopedPlotUpdate
    * @return a scoped handle that commits on destruction.
    */
-  ScopedUpdate beginUpdate() noexcept;
+  ScopedPlotUpdate beginUpdate() noexcept;
 
   /**
    * @brief Remove all plotted series, clearing the plot.
@@ -764,12 +572,12 @@ class Plot : public juce::Component {
    * its x-data if the number of values changed. */
   void updateSeriesYAt(std::span<const float> y_data, std::size_t series_index);
   /** @internal The y-buffer of the n-th normal series, empty if there is no
-   * such series. Shared by SeriesHandle and ScopedWrite. */
+   * such series. Shared by SeriesHandle and ScopedSeriesWrite. */
   std::span<float> seriesYBuffer(std::size_t series_index) noexcept;
   /** @internal How many normal series are plotted. */
   std::size_t normalSeriesCount() const noexcept;
   /** @internal Rescale, notify and repaint after series were updated in
-   * place. Deferred while a ScopedUpdate is open. */
+   * place. Deferred while a ScopedPlotUpdate is open. */
   void commitSeriesUpdate();
   /** @internal Whether every series of this type already holds exactly as
    * many x-values as the matching entry of 'y_data' has y-values. Must be
@@ -860,7 +668,7 @@ class Plot : public juce::Component {
   bool m_x_autoscale = true;
   bool m_y_autoscale = true;
   bool m_is_panning_or_zoomed_active = false;
-  /** How many ScopedUpdates are open. While non-zero, series updates defer
+  /** How many ScopedPlotUpdates are open. While non-zero, series updates defer
    * their rescale and repaint to the outermost one. */
   int m_open_update_count = 0;
   /** Whether a deferred update is waiting to be committed. */

--- a/include/include_internal/cmp_series.h
+++ b/include/include_internal/cmp_series.h
@@ -148,6 +148,15 @@ class Series : public juce::Component,
    */
   const std::vector<float>& getYData() const noexcept;
 
+  /** @brief Get the y-values for writing in place.
+   *
+   *  Lets a caller fill the series' own buffer instead of handing over values
+   *  to be copied. The length is fixed: use setYValues to change it.
+   *
+   *  @return a span over the y-values.
+   */
+  std::span<float> getYDataForWriting() noexcept;
+
   /** @brief Get x-values
    *
    *  Get a const reference of the x-values.

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -495,15 +495,15 @@ void Plot::SeriesHandle::setY(std::span<const float> y_values) const {
   m_plot->updateSeriesYAt(y_values, m_index);
 }
 
-Plot::ScopedYWrite Plot::SeriesHandle::write() const noexcept {
-  return ScopedYWrite{*m_plot, m_index};
+Plot::ScopedWrite Plot::SeriesHandle::writeY() const noexcept {
+  return ScopedWrite{*m_plot, m_index};
 }
 
-std::span<float> Plot::ScopedYWrite::values() const noexcept {
+std::span<float> Plot::ScopedWrite::values() const noexcept {
   return m_plot->seriesYBuffer(m_series_index);
 }
 
-Plot::ScopedYWrite::~ScopedYWrite() {
+Plot::ScopedWrite::~ScopedWrite() {
   // Nothing to redraw if the series went away while the handle was alive.
   if (values().empty()) return;
 

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -388,10 +388,12 @@ std::vector<std::vector<float>> Plot::generateXdataRamp(
 void Plot::plotSeries(std::span<const SeriesData> series) {
   // Validate before mutating any state, so a throw leaves the plot untouched.
   // An empty x is allowed: it auto-generates a 1..N ramp below.
-  for (const auto& s : series)
-    if (!s.x.empty() && s.x.size() != s.y.size())
+  for (const auto& s : series) {
+    if (!s.x.empty() && s.x.size() != s.y.size()) {
       throw std::invalid_argument(
           "plot: the x and y values of a series must have the same size.");
+    }
+  }
 
   // plot() sets the plot to exactly the given series; an empty list clears
   // them (there is no separate clear method).
@@ -433,8 +435,11 @@ void Plot::plotSeries(std::span<const SeriesData> series) {
 std::size_t Plot::normalSeriesCount() const noexcept {
   auto count = std::size_t{0};
 
-  for (const auto& series : *m_series)
-    if (series->getType() == SeriesType::normal) ++count;
+  for (const auto& series : *m_series) {
+    if (series->getType() == SeriesType::normal) {
+      ++count;
+    }
+  }
 
   return count;
 }
@@ -468,11 +473,11 @@ void Plot::commitSeriesUpdate() {
   repaint(m_axes_bounds);
 }
 
-Plot::ScopedUpdate::ScopedUpdate(Plot& plot) noexcept : m_plot{&plot} {
+ScopedPlotUpdate::ScopedPlotUpdate(Plot& plot) noexcept : m_plot{&plot} {
   ++m_plot->m_open_update_count;
 }
 
-Plot::ScopedUpdate::~ScopedUpdate() {
+ScopedPlotUpdate::~ScopedPlotUpdate() {
   --m_plot->m_open_update_count;
 
   // Only the outermost update commits, and only if anything was changed.
@@ -483,34 +488,36 @@ Plot::ScopedUpdate::~ScopedUpdate() {
   m_plot->commitSeriesUpdate();
 }
 
-Plot::ScopedUpdate Plot::beginUpdate() noexcept { return ScopedUpdate{*this}; }
+ScopedPlotUpdate Plot::beginUpdate() noexcept {
+  return ScopedPlotUpdate{*this};
+}
 
-std::size_t Plot::SeriesHandle::size() const noexcept {
+std::size_t SeriesHandle::size() const noexcept {
   return m_plot->seriesYBuffer(m_index).size();
 }
 
-void Plot::SeriesHandle::setY(std::span<const float> y_values) const {
+void SeriesHandle::setY(std::span<const float> y_values) const {
   if (!isValid()) return;
 
   m_plot->updateSeriesYAt(y_values, m_index);
 }
 
-Plot::ScopedWrite Plot::SeriesHandle::writeY() const noexcept {
-  return ScopedWrite{*m_plot, m_index};
+ScopedSeriesWrite SeriesHandle::writeY() const noexcept {
+  return ScopedSeriesWrite{*m_plot, m_index};
 }
 
-std::span<float> Plot::ScopedWrite::values() const noexcept {
+std::span<float> ScopedSeriesWrite::values() const noexcept {
   return m_plot->seriesYBuffer(m_series_index);
 }
 
-Plot::ScopedWrite::~ScopedWrite() {
+ScopedSeriesWrite::~ScopedSeriesWrite() {
   // Nothing to redraw if the series went away while the handle was alive.
   if (values().empty()) return;
 
   m_plot->commitSeriesUpdate();
 }
 
-void Plot::SeriesHandles::setY(
+void SeriesHandles::setY(
     std::span<const std::span<const float>> y_values) const {
   // One update for all of them: updating series one at a time rescales and
   // refreshes once per series, which grows with the square of the series
@@ -519,21 +526,22 @@ void Plot::SeriesHandles::setY(
 
   const auto count = std::min(m_count, y_values.size());
 
-  for (std::size_t i = 0; i < count; ++i)
+  for (std::size_t i = 0; i < count; ++i) {
     m_plot->updateSeriesYAt(y_values[i], i);
+  }
 }
 
-Plot::SeriesHandle Plot::series(const std::size_t series_index) noexcept {
+SeriesHandle Plot::series(const std::size_t series_index) noexcept {
   return SeriesHandle{*this, series_index};
 }
 
-Plot::SeriesHandles Plot::plot(const SeriesDataList& series) {
+SeriesHandles Plot::plot(const SeriesDataList& series) {
   plotSeries(series);
 
   return SeriesHandles{*this, normalSeriesCount()};
 }
 
-Plot::SeriesHandle Plot::plot(const SeriesData& series) {
+SeriesHandle Plot::plot(const SeriesData& series) {
   plotSeries({&series, 1});
 
   return SeriesHandle{*this, 0u};
@@ -575,8 +583,9 @@ void Plot::plotUpdateYOnly(std::span<const std::span<const float>> y_data) {
     std::vector<std::vector<float>> owned;
     owned.reserve(y_data.size());
 
-    for (const auto values : y_data)
+    for (const auto values : y_data) {
       owned.emplace_back(values.begin(), values.end());
+    }
 
     plotUpdateYOnly(owned);
     return;

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -430,9 +430,114 @@ void Plot::plotSeries(std::span<const SeriesData> series) {
   repaint();
 }
 
-void Plot::plot(const SeriesDataList& series) { plotSeries(series); }
+std::size_t Plot::normalSeriesCount() const noexcept {
+  auto count = std::size_t{0};
 
-void Plot::plot(const SeriesData& series) { plotSeries({&series, 1}); }
+  for (const auto& series : *m_series)
+    if (series->getType() == SeriesType::normal) ++count;
+
+  return count;
+}
+
+std::span<float> Plot::seriesYBuffer(const std::size_t series_index) noexcept {
+  auto remaining = series_index;
+
+  for (const auto& series : *m_series) {
+    if (series->getType() != SeriesType::normal) continue;
+
+    if (remaining == 0u) return series->getYDataForWriting();
+    --remaining;
+  }
+
+  return {};
+}
+
+void Plot::commitSeriesUpdate() {
+  // While an update is open the work is left to the outermost one, so that
+  // several series can be updated for the price of one rescale and repaint.
+  if (m_open_update_count > 0) {
+    m_series_update_pending = true;
+    return;
+  }
+
+  UNLIKELY if (m_y_autoscale && !m_is_panning_or_zoomed_active) {
+    setAutoYScale();
+  }
+
+  m_notify_components_on_update.notify();
+  repaint(m_axes_bounds);
+}
+
+Plot::ScopedUpdate::ScopedUpdate(Plot& plot) noexcept : m_plot{&plot} {
+  ++m_plot->m_open_update_count;
+}
+
+Plot::ScopedUpdate::~ScopedUpdate() {
+  --m_plot->m_open_update_count;
+
+  // Only the outermost update commits, and only if anything was changed.
+  if (m_plot->m_open_update_count > 0 || !m_plot->m_series_update_pending)
+    return;
+
+  m_plot->m_series_update_pending = false;
+  m_plot->commitSeriesUpdate();
+}
+
+Plot::ScopedUpdate Plot::beginUpdate() noexcept { return ScopedUpdate{*this}; }
+
+std::size_t Plot::SeriesHandle::size() const noexcept {
+  return m_plot->seriesYBuffer(m_index).size();
+}
+
+void Plot::SeriesHandle::setY(std::span<const float> y_values) const {
+  if (!isValid()) return;
+
+  m_plot->updateSeriesYAt(y_values, m_index);
+}
+
+Plot::ScopedYWrite Plot::SeriesHandle::write() const noexcept {
+  return ScopedYWrite{*m_plot, m_index};
+}
+
+std::span<float> Plot::ScopedYWrite::values() const noexcept {
+  return m_plot->seriesYBuffer(m_series_index);
+}
+
+Plot::ScopedYWrite::~ScopedYWrite() {
+  // Nothing to redraw if the series went away while the handle was alive.
+  if (values().empty()) return;
+
+  m_plot->commitSeriesUpdate();
+}
+
+void Plot::SeriesHandles::setY(
+    std::span<const std::span<const float>> y_values) const {
+  // One update for all of them: updating series one at a time rescales and
+  // refreshes once per series, which grows with the square of the series
+  // count.
+  auto update = m_plot->beginUpdate();
+
+  const auto count = std::min(m_count, y_values.size());
+
+  for (std::size_t i = 0; i < count; ++i)
+    m_plot->updateSeriesYAt(y_values[i], i);
+}
+
+Plot::SeriesHandle Plot::series(const std::size_t series_index) noexcept {
+  return SeriesHandle{*this, series_index};
+}
+
+Plot::SeriesHandles Plot::plot(const SeriesDataList& series) {
+  plotSeries(series);
+
+  return SeriesHandles{*this, normalSeriesCount()};
+}
+
+Plot::SeriesHandle Plot::plot(const SeriesData& series) {
+  plotSeries({&series, 1});
+
+  return SeriesHandle{*this, 0u};
+}
 
 void Plot::clear() { plotSeries({}); }
 
@@ -498,34 +603,48 @@ void Plot::plotUpdateYOnly(std::initializer_list<float> y_data) {
   plotUpdateYOnly(std::span<const float>(y_data.begin(), y_data.size()));
 }
 
-void Plot::plotUpdateYOnly(std::span<const float> y_data) {
+void Plot::updateSeriesYAt(std::span<const float> y_data,
+                           const std::size_t series_index) {
   jassert(!m_series->empty());
 
-  // Straight into the first series: wrapping the values in a vector of
-  // vectors to reach the multi-series overload would copy them an extra time
-  // and allocate, on the path that exists to avoid exactly that.
+  auto remaining = series_index;
+
+  // Straight into the series: wrapping the values in a vector of vectors to
+  // reach the multi-series overload would copy them an extra time and
+  // allocate, on the path that exists to avoid exactly that.
   for (const auto& series : *m_series) {
     if (series->getType() != SeriesType::normal) continue;
 
-    // A different number of values leaves the x-data describing a different
-    // number of points, so fall back to the path that regenerates it.
-    if (series->getXData().size() != y_data.size()) {
-      plotUpdateYOnly(
-          std::vector<std::vector<float>>{{y_data.begin(), y_data.end()}});
-      return;
+    if (remaining != 0u) {
+      --remaining;
+      continue;
     }
 
     series->setYValues(y_data);
+
+    // A different number of values would leave the x-data - and the
+    // pixel-point indices derived from it - describing a different number of
+    // points, so this series' x-data is regenerated as a ramp. The other
+    // series are left alone. This costs exactly the work updating only the
+    // y-values exists to avoid, hence the assert.
+    if (series->getXData().size() != y_data.size()) {
+      jassertfalse;
+
+      std::vector<float> ramp(y_data.size());
+      std::iota(ramp.begin(), ramp.end(), 1.0f);
+      series->setXValues(ramp);
+
+      if (m_x_autoscale && !m_is_panning_or_zoomed_active) setAutoXScale();
+    }
+
     break;
   }
 
-  // Matches what the multi-series path does through updateSeriesYData.
-  UNLIKELY if (m_y_autoscale && !m_is_panning_or_zoomed_active) {
-    setAutoYScale();
-  }
+  commitSeriesUpdate();
+}
 
-  m_notify_components_on_update.notify();
-  repaint(m_axes_bounds);
+void Plot::plotUpdateYOnly(std::span<const float> y_data) {
+  updateSeriesYAt(y_data, 0u);
 }
 
 void Plot::fillBetween(const std::vector<SpreadIndex>& spread_indices,

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -526,8 +526,10 @@ void SeriesHandles::setY(
 
   const auto count = std::min(m_count, y_values.size());
 
+  // Through the handles' own public setY, so this needs no privileged access
+  // to Plot of its own.
   for (std::size_t i = 0; i < count; ++i) {
-    m_plot->updateSeriesYAt(y_values[i], i);
+    (*this)[i].setY(y_values[i]);
   }
 }
 

--- a/source/cmp_series.cpp
+++ b/source/cmp_series.cpp
@@ -215,6 +215,8 @@ void Series::movePixelPoint(const juce::Point<float>& d_pixel_point,
 
 const std::vector<float>& Series::getYData() const noexcept { return m_y_data; }
 
+std::span<float> Series::getYDataForWriting() noexcept { return m_y_data; }
+
 const std::vector<float>& Series::getXData() const noexcept { return m_x_data; }
 
 const PixelPoints& Series::getPixelPoints() const noexcept {

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_series_handle_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_series_handle_test.cpp
+++ b/tests/unit_tests/cmp_series_handle_test.cpp
@@ -1,0 +1,237 @@
+#include <juce_core/juce_core.h>
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <span>
+#include <vector>
+
+#include "cmp_lookandfeel.h"
+#include "cmp_plot.h"
+#include "cmp_series.h"
+#include "cmp_test_helper.hpp"
+
+/* Tests for the handles returned by plot.
+ *
+ * A handle is what makes the ordering safe: there is no way to update a
+ * series without first having plotted one, because the update lives on what
+ * plot returns.
+ */
+SECTION(SeriesHandleTest, "Series handles") {
+  const auto seriesOf = [](cmp::Plot& plot) {
+    return getChildComponentHelper<cmp::Series>(plot);
+  };
+
+  const auto make = [](const std::size_t n, const float value) {
+    return std::vector<float>(n, value);
+  };
+
+  TEST("Plotting one series returns a handle to it") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({.y = make(8u, 1.f)});
+
+    expect(series.isValid());
+    expectEquals(series.size(), std::size_t(8u));
+  }
+
+  TEST("The handle sets the y-values") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({.y = make(4u, 1.f)});
+    series.setY(std::vector<float>{5.f, 6.f, 7.f, 8.f});
+
+    expectEqualVectors(seriesOf(plot).at(0)->getYData(),
+                       std::vector<float>{5.f, 6.f, 7.f, 8.f},
+                       [&](auto a, auto b) { expectEquals(a, b); });
+  }
+
+  TEST("The handle writes the series' own buffer, without copying") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({.y = make(16u, 0.f)});
+    const auto* buffer = seriesOf(plot).at(0)->getYData().data();
+
+    auto y = series.write();
+
+    expect(y.values().data() == buffer,
+           "the span must alias the series' own storage");
+    expectEquals(y.values().size(), std::size_t(16u));
+  }
+
+  TEST("Plotting a list returns a handle per series") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({{.y = make(4u, 1.f)}, {.y = make(4u, 2.f)}});
+
+    expectEquals(series.size(), std::size_t(2u));
+
+    series[0].setY(make(4u, 11.f));
+    series[1].setY(make(4u, 22.f));
+
+    expectEquals(seriesOf(plot).at(0)->getYData().at(0), 11.f);
+    expectEquals(seriesOf(plot).at(1)->getYData().at(0), 22.f);
+  }
+
+  TEST("The handles can be iterated") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({{.y = make(4u, 1.f)}, {.y = make(4u, 2.f)}});
+
+    auto count = std::size_t{0};
+    for (const auto one : series) {
+      expectEquals(one.size(), std::size_t(4u));
+      ++count;
+    }
+
+    expectEquals(count, std::size_t(2u));
+  }
+
+  TEST("A handle can be re-acquired after being discarded") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = make(4u, 1.f)});  // handle deliberately dropped
+
+    const auto series = plot.series(0u);
+
+    expect(series.isValid());
+    series.setY(make(4u, 9.f));
+
+    expectEquals(seriesOf(plot).at(0)->getYData().at(0), 9.f);
+  }
+
+  TEST("An index with no series gives an invalid handle") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = make(4u, 1.f)});
+
+    const auto missing = plot.series(7u);
+
+    expect(!missing.isValid());
+    expectEquals(missing.size(), std::size_t(0u));
+
+    // Updating through it must be a no-op rather than a crash.
+    missing.setY(make(4u, 1.f));
+  }
+
+  TEST("Plotting again while a handle is held does not dangle") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({.y = make(4u, 1.f)});
+    expect(series.isValid());
+
+    plot.clear();
+
+    expect(!series.isValid());
+    expectEquals(series.size(), std::size_t(0u));
+  }
+
+  TEST("An update batches the series refresh until it closes") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series =
+        plot.plot({{.y = make(64u, 0.f)}, {.y = make(64u, 0.f)}});
+
+    // Fixed limits, so a change in the values actually moves the pixel points
+    // instead of being normalised away by autoscaling.
+    plot.setYLim(0.f, 1000.f);
+
+    // The pixel points are recomputed when a series update is committed, so
+    // they show whether the work was deferred.
+    const auto first_pixel_y = [&] {
+      return seriesOf(plot).at(0)->getPixelPoints().at(0).getY();
+    };
+
+    const auto before = first_pixel_y();
+
+    {
+      auto update = plot.beginUpdate();
+
+      series[0].setY(make(64u, 500.f));
+      series[1].setY(make(64u, 500.f));
+
+      // Still the old projection: the refresh is waiting for the update to
+      // close.
+      expectEquals(first_pixel_y(), before);
+    }
+
+    // Closing the update refreshed it once, for both series.
+    expect(first_pixel_y() != before,
+           "closing the update must refresh the series");
+  }
+
+  TEST("Nested updates commit once, at the outermost") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({.y = make(32u, 0.f)});
+
+    plot.setYLim(0.f, 1000.f);
+
+    const auto first_pixel_y = [&] {
+      return seriesOf(plot).at(0)->getPixelPoints().at(0).getY();
+    };
+
+    const auto before = first_pixel_y();
+
+    {
+      auto outer = plot.beginUpdate();
+      {
+        auto inner = plot.beginUpdate();
+        series.setY(make(32u, 250.f));
+      }
+
+      // The inner one closing must not have committed.
+      expectEquals(first_pixel_y(), before);
+    }
+
+    expect(first_pixel_y() != before, "the outermost update must commit");
+  }
+
+  TEST("Setting every series at once batches without being asked to") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    const auto series = plot.plot({{.y = make(8u, 0.f)}, {.y = make(8u, 0.f)}});
+
+    plot.setYLim(0.f, 1000.f);
+
+    const auto first_pixel_y = [&] {
+      return seriesOf(plot).at(0)->getPixelPoints().at(0).getY();
+    };
+
+    const auto before = first_pixel_y();
+
+    const auto left = make(8u, 400.f);
+    const auto right = make(8u, 600.f);
+    const std::array<std::span<const float>, 2> channels{
+        std::span<const float>(left), std::span<const float>(right)};
+
+    series.setY(channels);
+
+    expectEquals(seriesOf(plot).at(0)->getYData().at(0), 400.f);
+    expectEquals(seriesOf(plot).at(1)->getYData().at(0), 600.f);
+    expect(first_pixel_y() != before, "the series must have been refreshed");
+  }
+
+  TEST("An update that changes nothing does not force a refresh") {
+    cmp::Plot plot;
+    plot.setBounds(0, 0, 500, 400);
+
+    plot.plot({.y = make(8u, 1.f)});
+
+    // Opening and closing without touching a series is harmless.
+    { auto update = plot.beginUpdate(); }
+
+    expectEquals(seriesOf(plot).at(0)->getYData().size(), std::size_t(8u));
+  }
+}

--- a/tests/unit_tests/cmp_series_handle_test.cpp
+++ b/tests/unit_tests/cmp_series_handle_test.cpp
@@ -55,7 +55,7 @@ SECTION(SeriesHandleTest, "Series handles") {
     const auto series = plot.plot({.y = make(16u, 0.f)});
     const auto* buffer = seriesOf(plot).at(0)->getYData().data();
 
-    auto y = series.write();
+    auto y = series.writeY();
 
     expect(y.values().data() == buffer,
            "the span must alias the series' own storage");


### PR DESCRIPTION
Stacked on #76. Supersedes #77, which this rolls in and improves.

## The problem

Updating a series required calling `plot` first — a precondition the type
system knew nothing about. It was documented, asserted, and got the
out-of-bounds read fixed in #75. All three are symptoms of the same thing:
the ordering was enforced by convention.

## The change

`plot` returns handles, so there is no way to update a series without having
plotted one — the update lives on what `plot` returns:

```cpp
auto series = plot.plot({.y = data});

series.setY(new_values);
auto y = series.write();     // zero-copy, sized to the series
```

**Source-compatible**: adding a return value to a function that returned
`void` breaks nobody. The entire existing test suite compiles unchanged.

Two things worth calling out in the design:

- **The list overload returns a non-allocating range**, not a
  `std::vector<SeriesHandle>`. A vector would allocate on every `plot()`,
  including the per-frame varying-size case — a regression for exactly the
  callers who cannot use the y-only path.
- **Handles refer to their series by position and re-resolve on use**, so
  plotting again while a handle is held leaves it invalid rather than
  dangling. `plot.series(i)` re-acquires one that was not kept.

## Batching, and why it is not optional

Committing per series rescales, notifies and repaints per series — and the
rescale walks *every* series, so the cost grows with the square of the count.
Measured at 2048 points per channel:

| channels | multi-call | batched loop | **unbatched loop** |
|---|---|---|---|
| 2 | 26.0 us | 24.7 us | 49.0 us |
| 4 | 52.5 us | 50.0 us | 196.0 us |
| 8 | 101.4 us | 101.1 us | 793.8 us |
| 16 | 213.5 us | 202.5 us | **3167.4 us** |

A naive loop over handles is **15.6x slower at 16 channels**. That is a worse
footgun than the one being removed, so the batching is built in rather than
left to the caller:

```cpp
channels.setY(std::array{left, right});   // batched, cannot be forgotten
```

`ScopedUpdate` is there for hand-rolled batching (`plot.beginUpdate()`), and
nests. The batched path matches today's `plotUpdateYOnly(channels)` to within
5% at 2–16 channels, so nothing is lost by preferring it.

## Tests

Eleven new, suite at 149 sections, all passing:

- plotting returns a valid handle, sized correctly
- the handle sets values, and `write()` **aliases the series' own storage**
  (pointer identity)
- a list returns a handle per series, and they iterate
- `plot.series(i)` re-acquires; an out-of-range index gives an invalid handle
  whose `setY` is a no-op rather than a crash
- plotting again under a live handle does not dangle
- **an update defers the refresh until it closes** (checked via pixel points,
  not by trusting the flag)
- nested updates commit once, at the outermost
- `setY` over all series batches without being asked to
- an update that changes nothing does not force a refresh

## Not in this PR

`plotUpdateYOnly` is untouched and still works. Removing it is stacked on top
of this, now that every one of its uses has a measured replacement.
