### PR TITLE
Plot: Remove plotUpdateYOnly in favour of series handles

### DIFF
--- a/include/include/cmp_plot.h
+++ b/include/include/cmp_plot.h
@@ -303,6 +303,16 @@ class Plot : public juce::Component {
   SeriesHandle series(const std::size_t series_index) noexcept;
 
   /**
+   * @brief Get handles to every plotted series.
+   *
+   * The same range 'plot' returns, for code that plots in one place and
+   * updates in another.
+   *
+   * @return handles to the plotted series.
+   */
+  SeriesHandles series() noexcept;
+
+  /**
    * @brief Batch several series updates into one rescale and repaint.
    *
    * @see ScopedUpdate
@@ -341,74 +351,10 @@ class Plot : public juce::Component {
   void plotVerticalLines(const std::vector<float> &x_coordinates,
                          const SeriesAttributeList &series_attributes = {});
 
-  /** @brief Plot, but only update the y-data.
-   *
-   * This plot function will only update the y-data in the series and only
-   * repaint the axes_area, therefore requires less CPU than the 'plot'
-   * function. x-data must be set through the 'plot' function before calling
-   * this function.
-   *
-   * Pass the same number of y-values as the series already holds. Passing a
-   * different number is handled - the x-data is regenerated as a ramp, which
-   * replaces any x-data set through 'plot' - but it costs exactly the work
-   * this function exists to avoid, so prefer 'plot' when the number of points
-   * changes.
-   *
-   * @param y_data vector of vectors with the y-values.
-   */
-  void plotUpdateYOnly(const std::vector<std::vector<float>> &y_data);
-
-  /** @brief Update only the y-data of a single series.
-   *
-   * Convenience overload for the common real-time case of one series, so the
-   * y-values need not be wrapped in an extra pair of braces:
-   * @code plotUpdateYOnly(samples); @endcode
-   *
-   * Takes a span, so the values can come from any contiguous range - a
-   * vector, a std::array, a raw buffer, or a sub-range of a larger one -
-   * without being packed into a vector first, and are copied straight into
-   * the series:
-   * @code plotUpdateYOnly({fft_buffer.data(), fft_size}); @endcode
-   *
-   * @param y_data the new y-values for the first series.
-   */
-  void plotUpdateYOnly(std::span<const float> y_data);
-
-  /** @brief Plot, but only update the y-data, for several series.
-   *
-   * As the vector-of-vectors overload, but each series' values can come from
-   * any contiguous range. A caller holding one buffer per channel - which is
-   * how audio arrives - can plot them without first copying everything into a
-   * vector of vectors:
-   *
-   * @code
-   *   const std::array<std::span<const float>, 2> channels{
-   *       std::span(buffer.getReadPointer(0), num_samples),
-   *       std::span(buffer.getReadPointer(1), num_samples)};
-   *
-   *   plot.plotUpdateYOnly(channels);
-   * @endcode
-   *
-   * Note that a vector of vectors does not convert to a span of spans, so
-   * such callers keep using the overload above.
-   *
-   * @param y_data one range of y-values per series.
-   */
-  void plotUpdateYOnly(std::span<const std::span<const float>> y_data);
-
-  /** @brief Update only the y-data of a single series, from a braced list.
-   *
-   * A braced list does not convert to a span, so this overload keeps
-   * @code plotUpdateYOnly({4.f, 3.f, 2.f, 1.f}); @endcode working.
-   *
-   * @param y_data the new y-values for the first series.
-   */
-  void plotUpdateYOnly(std::initializer_list<float> y_data);
-
   /** @brief Fill the area between two data lines
    *
    * Steps to use:
-   * 1. Draw series using plot() or plotUpdateYOnly()
+   * 1. Draw series using plot()
    * 2. Call this function to fill area between specified lines
    *
    * @param spread_indices Indices of series to fill between

--- a/source/cmp_plot.cpp
+++ b/source/cmp_plot.cpp
@@ -347,8 +347,8 @@ void Plot::plotInternal(const std::vector<std::vector<float>>& y_data,
       update_y_data_only && seriesXSizesMatch<t_series_type>(y_data);
 
   // Reaching this in a y-only update means the caller changed the number of
-  // values, which costs the x-data update that plotUpdateYOnly exists to
-  // avoid. It is handled, but it is worth knowing about.
+  // values, which costs the x-data update that updating only the y-values
+  // exists to avoid. It is handled, but it is worth knowing about.
   jassert(!update_y_data_only || keep_existing_x_data);
 
   updateSeriesYData<t_series_type>(y_data, series_attributes);
@@ -527,6 +527,10 @@ Plot::SeriesHandle Plot::series(const std::size_t series_index) noexcept {
   return SeriesHandle{*this, series_index};
 }
 
+Plot::SeriesHandles Plot::series() noexcept {
+  return SeriesHandles{*this, normalSeriesCount()};
+}
+
 Plot::SeriesHandles Plot::plot(const SeriesDataList& series) {
   plotSeries(series);
 
@@ -540,68 +544,6 @@ Plot::SeriesHandle Plot::plot(const SeriesData& series) {
 }
 
 void Plot::clear() { plotSeries({}); }
-
-void Plot::plotUpdateYOnly(const std::vector<std::vector<float>>& y_data) {
-  plotInternal<SeriesType::normal>(y_data, {}, {}, true);
-  repaint(m_axes_bounds);
-}
-
-void Plot::plotUpdateYOnly(std::span<const std::span<const float>> y_data) {
-  jassert(!m_series->empty());
-
-  // The x-data can only be left alone if every series is being given as many
-  // values as it already holds, and there is a series for every range.
-  auto series_count = std::size_t{0};
-  auto keep_existing_x_data = true;
-
-  for (const auto& series : *m_series) {
-    if (series->getType() != SeriesType::normal) continue;
-
-    if (series_count >= y_data.size() ||
-        series->getXData().size() != y_data[series_count].size()) {
-      keep_existing_x_data = false;
-      break;
-    }
-
-    ++series_count;
-  }
-
-  if (series_count != y_data.size()) keep_existing_x_data = false;
-
-  if (!keep_existing_x_data) {
-    // Hand over to the path that regenerates the x-data. This is the only
-    // case that copies into a vector of vectors, and it is already the slow
-    // path.
-    std::vector<std::vector<float>> owned;
-    owned.reserve(y_data.size());
-
-    for (const auto values : y_data)
-      owned.emplace_back(values.begin(), values.end());
-
-    plotUpdateYOnly(owned);
-    return;
-  }
-
-  auto values_it = y_data.begin();
-
-  for (const auto& series : *m_series) {
-    if (series->getType() != SeriesType::normal) continue;
-
-    series->setYValues(*values_it++);
-  }
-
-  // Matches what the multi-series path does through updateSeriesYData.
-  UNLIKELY if (m_y_autoscale && !m_is_panning_or_zoomed_active) {
-    setAutoYScale();
-  }
-
-  m_notify_components_on_update.notify();
-  repaint(m_axes_bounds);
-}
-
-void Plot::plotUpdateYOnly(std::initializer_list<float> y_data) {
-  plotUpdateYOnly(std::span<const float>(y_data.begin(), y_data.size()));
-}
 
 void Plot::updateSeriesYAt(std::span<const float> y_data,
                            const std::size_t series_index) {
@@ -641,10 +583,6 @@ void Plot::updateSeriesYAt(std::span<const float> y_data,
   }
 
   commitSeriesUpdate();
-}
-
-void Plot::plotUpdateYOnly(std::span<const float> y_data) {
-  updateSeriesYAt(y_data, 0u);
 }
 
 void Plot::fillBetween(const std::vector<SpreadIndex>& spread_indices,

--- a/tests/gui/realtime/rt_tests.cpp
+++ b/tests/gui/realtime/rt_tests.cpp
@@ -5,6 +5,9 @@
  * https://opensource.org/licenses/MIT
  */
 
+#include <span>
+#include <vector>
+
 #include "cmp_lookandfeel.h"
 #include "test_macros.h"
 
@@ -62,7 +65,7 @@ TEST(real_time_plot_function, real_time) {
       y = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     }
 
-    GET_PLOT->plotUpdateYOnly(y_test_data);
+    GET_PLOT->series(0u).setY(y_test_data);
   };
 }
 
@@ -98,7 +101,13 @@ TEST(spread, real_time) {
   FILL_BETWEEN(spread_indices);
 
   GET_TIMER_CB = [=](const int dt_ms) {
-    GET_PLOT->plotUpdateYOnly(getYData());
+    const auto y_data = getYData();
+
+    std::vector<std::span<const float>> channels;
+    channels.reserve(y_data.size());
+    for (const auto& y : y_data) channels.emplace_back(y);
+
+    GET_PLOT->series().setY(channels);
   };
 }
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_update_y_only_test.cpp cmp_span_api_test.cpp cmp_series_handle_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
+add_executable(cmp_plot_test cmp_main_test.cpp cmp_plot_test.cpp cmp_utils_test.cpp cmp_datamodels_test.cpp cmp_downsampler_test.cpp cmp_downsampler_pixel_test.cpp cmp_trace_test.cpp cmp_pixel_points_test.cpp cmp_axis_transform_test.cpp cmp_math3d_test.cpp cmp_camera3d_test.cpp cmp_projector3d_test.cpp cmp_series3d_test.cpp cmp_handle_set_y_size_test.cpp cmp_span_api_test.cpp cmp_series_handle_test.cpp cmp_axes3dbox_test.cpp cmp_plot3d_test.cpp)
 target_link_libraries(cmp_plot_test cmp_plot juce::juce_core juce::juce_events CURL::libcurl)
 target_include_directories(cmp_plot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/include_internal ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME cmp_plot_test COMMAND cmp_plot_test)

--- a/tests/unit_tests/cmp_handle_set_y_size_test.cpp
+++ b/tests/unit_tests/cmp_handle_set_y_size_test.cpp
@@ -1,5 +1,7 @@
 #include <juce_core/juce_core.h>
 
+#include <array>
+#include <span>
 #include <vector>
 
 #include "cmp_lookandfeel.h"
@@ -7,16 +9,16 @@
 #include "cmp_series.h"
 #include "cmp_test_helper.hpp"
 
-/* Tests for plotUpdateYOnly when the number of y-values changes.
+/* Tests for updating a series' y-values when the number of them changes.
  *
- * plotUpdateYOnly skips the x-data update, which is where its speed comes
- * from. If the caller passes a different number of values, keeping the old
- * x-data would leave it - and the pixel-point indices derived from it -
- * describing a different number of points than the series holds, so indices
- * would be used to read past the end of the y-data. The x-data is regenerated
- * in that case instead.
+ * Updating only the y-values skips the x-data update, which is where its
+ * speed comes from. If the caller passes a different number of values,
+ * keeping the old x-data would leave it - and the pixel-point indices derived
+ * from it - describing a different number of points than the series holds, so
+ * indices would be used to read past the end of the y-data. The x-data is
+ * regenerated in that case instead.
  */
-SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
+SECTION(UpdateYOnlySizeTest, "Handle setY size change") {
   const auto make = [](const std::size_t n, const float value) {
     return std::vector<float>(n, value);
   };
@@ -38,7 +40,7 @@ SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
 
     const std::vector<float> x_data = make(500u, 3.f);
     plot.plot({.x = x_data, .y = make(500u, 1.f)});
-    plot.plotUpdateYOnly(make(500u, 2.f));
+    plot.series(0u).setY(make(500u, 2.f));
 
     const auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 1ul);
@@ -56,7 +58,7 @@ SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
     plot.setBounds(0, 0, 500, 400);
 
     plot.plot({.y = make(500u, 1.f)});
-    plot.plotUpdateYOnly(make(10u, 2.f));
+    plot.series(0u).setY(make(10u, 2.f));
 
     const auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 1ul);
@@ -71,7 +73,7 @@ SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
     plot.setBounds(0, 0, 500, 400);
 
     plot.plot({.y = make(10u, 1.f)});
-    plot.plotUpdateYOnly(make(500u, 2.f));
+    plot.series(0u).setY(make(500u, 2.f));
 
     const auto series = getChildComponentHelper<cmp::Series>(plot);
 
@@ -87,7 +89,7 @@ SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
     plot.plot({.y = make(300u, 1.f)});
 
     for (const std::size_t n : {50u, 700u, 20u, 300u, 1u}) {
-      plot.plotUpdateYOnly(make(n, 2.f));
+      plot.series(0u).setY(make(n, 2.f));
 
       const auto series = getChildComponentHelper<cmp::Series>(plot);
 
@@ -102,7 +104,12 @@ SECTION(UpdateYOnlySizeTest, "plotUpdateYOnly size change") {
     plot.setBounds(0, 0, 500, 400);
 
     plot.plot({{.y = make(200u, 1.f)}, {.y = make(200u, 2.f)}});
-    plot.plotUpdateYOnly({make(30u, 3.f), make(30u, 4.f)});
+    const auto first = make(30u, 3.f);
+    const auto second = make(30u, 4.f);
+    const std::array<std::span<const float>, 2> channels{
+        std::span<const float>(first), std::span<const float>(second)};
+
+    plot.series().setY(channels);
 
     const auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 2ul);

--- a/tests/unit_tests/cmp_plot_test.cpp
+++ b/tests/unit_tests/cmp_plot_test.cpp
@@ -2,7 +2,9 @@
 
 #include <juce_core/juce_core.h>
 
+#include <array>
 #include <memory>
+#include <span>
 
 #include "cmp_datamodels.h"
 #include "cmp_lookandfeel.h"
@@ -54,11 +56,10 @@ SECTION(PlotClass, "Plot class") {
     cmp::Plot bundle_plot;
     // First series supplies its own x; second omits x and should get a 1..N
     // ramp; the first also carries a per-series colour attribute.
-    bundle_plot.plot(
-        {{.x = x_data2,
-          .y = y_data2,
-          .attribute = {.series_colour = juce::Colours::red}},
-         {.y = y_data1}});
+    bundle_plot.plot({{.x = x_data2,
+                       .y = y_data2,
+                       .attribute = {.series_colour = juce::Colours::red}},
+                      {.y = y_data1}});
     auto series = getChildComponentHelper<cmp::Series>(bundle_plot);
     expectEquals(series.size(), 2ul);
     expectEqualVectors(series[0]->getXData(), x_data2, expectEqualsLambda);
@@ -120,10 +121,16 @@ SECTION(PlotClass, "Plot class") {
   }
 
   TEST("Update Y data only") {
-    plot.plot({{.x = x_data_random_1, .y = y_data1},
-               {.x = x_data_random_2, .y = y_data2},
-               {.x = x_data_random_3, .y = y_data3}});
-    plot.plotUpdateYOnly({y_data1, y_data2, y_data3});
+    const auto series_handles =
+        plot.plot({{.x = x_data_random_1, .y = y_data1},
+                   {.x = x_data_random_2, .y = y_data2},
+                   {.x = x_data_random_3, .y = y_data3}});
+
+    const std::array<std::span<const float>, 3> new_y{
+        std::span<const float>(y_data1), std::span<const float>(y_data2),
+        std::span<const float>(y_data3)};
+
+    series_handles.setY(new_y);
     auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 3ul);
     expectEqualVectors(series[0]->getXData(), x_data_random_1,

--- a/tests/unit_tests/cmp_span_api_test.cpp
+++ b/tests/unit_tests/cmp_span_api_test.cpp
@@ -24,7 +24,7 @@ SECTION(SpanApiTest, "Span y-data") {
     plot.setBounds(0, 0, 500, 400);
 
     plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
-    plot.plotUpdateYOnly(std::vector<float>{5.f, 6.f, 7.f, 8.f});
+    plot.series(0u).setY(std::vector<float>{5.f, 6.f, 7.f, 8.f});
 
     expectEqualVectors(firstSeries(plot)->getYData(),
                        std::vector<float>{5.f, 6.f, 7.f, 8.f},
@@ -36,7 +36,7 @@ SECTION(SpanApiTest, "Span y-data") {
     plot.setBounds(0, 0, 500, 400);
 
     plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
-    plot.plotUpdateYOnly({5.f, 6.f, 7.f, 8.f});
+    plot.series(0u).setY(std::vector<float>{5.f, 6.f, 7.f, 8.f});
 
     expectEqualVectors(firstSeries(plot)->getYData(),
                        std::vector<float>{5.f, 6.f, 7.f, 8.f},
@@ -50,7 +50,7 @@ SECTION(SpanApiTest, "Span y-data") {
     plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
 
     const std::array<float, 4> values{9.f, 8.f, 7.f, 6.f};
-    plot.plotUpdateYOnly(values);
+    plot.series(0u).setY(values);
 
     expectEqualVectors(firstSeries(plot)->getYData(),
                        std::vector<float>{9.f, 8.f, 7.f, 6.f},
@@ -64,7 +64,7 @@ SECTION(SpanApiTest, "Span y-data") {
     plot.plot({.y = std::vector<float>{1.f, 2.f, 3.f, 4.f}});
 
     float buffer[4] = {2.f, 4.f, 6.f, 8.f};
-    plot.plotUpdateYOnly(std::span<const float>(buffer, 4));
+    plot.series(0u).setY(std::span<const float>(buffer, 4));
 
     expectEqualVectors(firstSeries(plot)->getYData(),
                        std::vector<float>{2.f, 4.f, 6.f, 8.f},
@@ -79,7 +79,7 @@ SECTION(SpanApiTest, "Span y-data") {
 
     // The middle three of a longer buffer, with no intermediate copy.
     const std::vector<float> big{1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-    plot.plotUpdateYOnly(std::span<const float>(big).subspan(2u, 3u));
+    plot.series(0u).setY(std::span<const float>(big).subspan(2u, 3u));
 
     expectEqualVectors(firstSeries(plot)->getYData(),
                        std::vector<float>{3.f, 4.f, 5.f},
@@ -101,7 +101,7 @@ SECTION(SpanApiTest, "Span y-data") {
     const std::array<std::span<const float>, 2> channels{
         std::span<const float>(left, 4), std::span<const float>(right, 4)};
 
-    plot.plotUpdateYOnly(channels);
+    plot.series().setY(channels);
 
     const auto series = getChildComponentHelper<cmp::Series>(plot);
     expectEquals(series.size(), 2ul);
@@ -124,7 +124,7 @@ SECTION(SpanApiTest, "Span y-data") {
     const std::array<std::span<const float>, 2> channels{
         std::span<const float>(shorter), std::span<const float>(shorter)};
 
-    plot.plotUpdateYOnly(channels);
+    plot.series().setY(channels);
 
     for (const auto* series : getChildComponentHelper<cmp::Series>(plot)) {
       expectEquals(series->getYData().size(), std::size_t(12u));
@@ -137,7 +137,7 @@ SECTION(SpanApiTest, "Span y-data") {
     plot.setBounds(0, 0, 500, 400);
 
     plot.plot({.y = std::vector<float>(200u, 1.f)});
-    plot.plotUpdateYOnly(std::vector<float>(20u, 2.f));
+    plot.series(0u).setY(std::vector<float>(20u, 2.f));
 
     const auto* series = firstSeries(plot);
 

--- a/tests/unit_tests/cmp_trace_test.cpp
+++ b/tests/unit_tests/cmp_trace_test.cpp
@@ -62,7 +62,7 @@ SECTION(TraceClass, "Trace class") {
   }
 
   TEST("Update existing plot Y only") {
-    plot.plotUpdateYOnly({4.f, 3.f, 2.f, 1.f});
+    plot.series(0u).setY(std::vector<float>{4.f, 3.f, 2.f, 1.f});
     auto trace_points = getChildComponentHelper<TracePoint_f>(plot);
     expect(!trace_points.empty());
     expectEquals(trace_points.size(), 2ul);


### PR DESCRIPTION
Stacked on #79 (handles), which is on #76. Base moves down as they merge.

## Why

`plotUpdateYOnly` is the function with the ordering problem — the one that
documented "call plot first", asserted it, and produced the out-of-bounds
read fixed in #75. Now that every one of its overloads has a replacement on
the handles `plot` returns, keeping it means two ways to do the same thing
where one of them is the unsafe one.

| before | after |
|---|---|
| `plotUpdateYOnly(y)` | `plot.series(0u).setY(y)` |
| `plotUpdateYOnly(span)` | `handle.setY(span)` |
| `plotUpdateYOnly(spans)` | `handles.setY(spans)` |
| `plotUpdateYOnly({1.f, 2.f})` | `handle.setY(std::vector<float>{…})` |

The handle form **cannot be called without having plotted** — that is the
whole point.

## Also added

`Plot::series()` with no index, returning handles to every plotted series, so
code that plots in one place and updates in another need not carry them
around. It is what makes the multi-series migration possible without
re-plotting.

## Migration

All internal call sites moved: the plot, trace and span tests, the
size-change tests (file renamed to match what it now tests), and **both
real-time GUI test apps**. The spread test now builds spans over its per-tick
data instead of handing over a vector of vectors.

## Verification

- Suite stays at **149 sections, all passing** — the same count as before the
  removal, so nothing was dropped rather than migrated.
- **All three GUI test apps build** (`real_time`, `non_real_time`, `plot3d`).
- Zero references to `plotUpdateYOnly` remain anywhere in `source/`,
  `include/`, `tests/` or the README.

## Breaking

This removes public API. It is a deliberate break, batched with #76 and #79
so downstream code changes once rather than three times. The external
real-time example will need the same one-line migration.
